### PR TITLE
setup_xfs.yml doesnt account for more than one volume group

### DIFF
--- a/tasks/system/general/setup_xfs.yml
+++ b/tasks/system/general/setup_xfs.yml
@@ -11,7 +11,7 @@
     force: true
 
 - name: Define size of swap
-  shell: SWAP_MAX_SIZE=$(sudo vgdisplay --units M ${LVG} | grep "VG Size" | awk '{ print mem=int(0.07*$3) }'); grep MemTotal /proc/meminfo | awk -v MAXMEM=${SWAP_MAX_SIZE} '{ mem=int($2/(2*1024)); if(mem>MAXMEM) mem=MAXMEM; print mem; }'
+  shell: SWAP_MAX_SIZE=$(sudo vgdisplay --units M lxc | grep "VG Size" | awk '{ print mem=int(0.07*$3) }'); grep MemTotal /proc/meminfo | awk -v MAXMEM=${SWAP_MAX_SIZE} '{ mem=int($2/(2*1024)); if(mem>MAXMEM) mem=MAXMEM; print mem; }'
   register: swap_size
 
 - name: Create swap volume


### PR DESCRIPTION
If Ubuntu is installed and the LVM option is selected, when the command below runs it grabs both VG sizes

```bash
SWAP_MAX_SIZE=$(sudo vgdisplay --units M ${LVG} | grep "VG Size" | awk '{ print mem=int(0.07*$3) }'); grep MemTotal /proc/meminfo | awk -v MAXMEM=${SWAP_MAX_SIZE} '{ mem=int($2/(2*1024)); if(mem>MAXMEM) mem=MAXMEM; print mem; }'
```

In my case:
```bash
SWAP_MAX_SIZE=$(sudo vgdisplay --units M ${LVG} | grep "VG Size" | awk '{ print mem=int(0.07*$3) }'); echo $SWAP_MAX_SIZE
9566 4810
```
When awk goes to run:
```bash
elastic@ece-r1-director:~$ awk -v MAXMEM=${SWAP_MAX_SIZE} '{mem=int($2/(2*1024)); if(mem>MAXMEM) mem=MAXMEM; print mem;}'
```
The variable will get populated to, and throw the error:
```bash
elastic@ece-r1-director:~$ awk -v MAXMEM=9566 4180 '{mem=int($2/(2*1024)); if(mem>MAXMEM) mem=MAXMEM; print mem;}'
awk: fatal: cannot open file `{mem=int($2/(2*1024)); if(mem>MAXMEM) mem=MAXMEM; print mem;}' for reading (No such file or directory)
```

Might as well refer to the vg that is being created rather than calling for all