### PR TITLE
Fix typo in sysctl module

### DIFF
--- a/tasks/system/general/sysctl_scripts.yml
+++ b/tasks/system/general/sysctl_scripts.yml
@@ -1,6 +1,6 @@
 ---
 - name: sysctl_scripts.yml || set sysctl items
-  systctl:
+  sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     reload: yes


### PR DESCRIPTION
Fixes a typo in `sysctl_scripts.yml` systctl -> sysctl