### PR TITLE
SLES12: Retry "Reload repositories" step

### DIFF
--- a/tasks/system/SLES-12/install_docker.yml
+++ b/tasks/system/SLES-12/install_docker.yml
@@ -34,6 +34,10 @@
 
 - name: Reload repositories
   command: "zypper --gpg-auto-import-keys refresh"
+  register: repo_reloaded
+  retries: 10
+  delay: 30
+  until: repo_reloaded is success
   args:
     warn: false
 


### PR DESCRIPTION
Due to locking issues with zypper, retry the "Reload repositories" step