### PR TITLE
Adding RHEL and CentOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ The following variables are avaible:
     - Default: [director, coordinator, proxy, allocator]
 - `availability_zone`: The availability zone this group of hosts belongs to
 - `ece_version`: The Elastic Cloud Enterprise version that should get installed
-    - Default: 2.1.0
+    - Default: 2.2.0
 - `ece_docker_registry`: The docker registry from where to pull the Elastic Cloud Enterprise images. This is only relevant if you have a private mirror 
     - Default: docker.elastic.co
 - `ece_docker_repository`: The docker repository in the given registry. This is only relevant if you have a private mirror
     - Default: cloud-enterprise
 - `ece_installer_url`: The location of the installation script. Can be a local file for offline installation.
     - Default: `https://download.elastic.co/cloud/elastic-cloud-enterprise.sh`
-- `docker_config`: If specified as a path to a docker config, copies it to the target hosts
+- `docker_config`: If specified as a path to a docker config, copies it to the target hosts  
+- [Supported Docker Versions](https://elastic.co/en/cloud-enterprise/current/ece-prereqs-software.html)  
+  - `docker_version`: Supported version on CentOS 7, Ubuntu (14.04LTS, 16.04LTS) and SLES 12 is 18.09, Supported version on RHEL7 is 1.13  
 
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host
@@ -184,13 +186,13 @@ all:
 You only need to run the upgrade on a single host, it will then automatically propagate to all other hosts.
 An upgrade is usually performed on the first host you installed Elastic Cloud Enterprise on, but it can also be run from any host that holds the director role.
 
-Assuming you have an installation of Elastic Cloud Enterprise 2.0.0 and want to upgrade to 2.1.0 `site.yml` could then look like:
+Assuming you have an installation of Elastic Cloud Enterprise 2.1.0 and want to upgrade to 2.2.0 `site.yml` could then look like:
 ```yaml
 - hosts: upgradehost
   roles:
     - elastic-cloud-enterprise
   vars:
-    ece_version: 2.1.0
+    ece_version: 2.2.0
 ```
 
 with `inventory.yml`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 2.1.0
+ece_version: 2.2.0
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""

--- a/tasks/system/CentOS-7/install_docker.yml
+++ b/tasks/system/CentOS-7/install_docker.yml
@@ -1,0 +1,35 @@
+---
+- name: Remove docker
+  package:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+    - docker
+  register: remove_packages
+  retries: 10
+  delay: 30
+  until: remove_packages is success
+
+- name: Add Docker GPG Key
+  rpm_key:
+    key: https://download.docker.com/linux/centos/gpg
+    state: present
+
+- name: Add docker repository
+  yum_repository:
+    name: "{{ docker_version_map[docker_version]['name'] }}"
+    description: "Docker repository"
+    file: docker-ce
+    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    enabled: yes
+    gpgcheck: no
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present

--- a/tasks/system/CentOS-7/main.yml
+++ b/tasks/system/CentOS-7/main.yml
@@ -1,0 +1,3 @@
+---
+- include_tasks: install_docker.yml
+  tags: [install_docker, destructive]

--- a/tasks/system/RedHat-7/install_dependencies.yml
+++ b/tasks/system/RedHat-7/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install base dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - lvm2

--- a/tasks/system/RedHat-7/install_docker.yml
+++ b/tasks/system/RedHat-7/install_docker.yml
@@ -1,0 +1,43 @@
+---
+- name: Remove docker
+  package:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+    - docker
+  register: remove_packages
+  retries: 10
+  delay: 30
+  until: remove_packages is success
+
+- name: Add Docker GPG Key
+  rpm_key:
+    key: https://download.docker.com/linux/centos/gpg
+    state: present
+
+- name: Add docker repository
+  yum_repository:
+    name: "{{ docker_version_map[docker_version]['name'] }}"
+    description: "Docker repository"
+    file: docker-ce
+    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    enabled: yes
+    gpgcheck: no
+  when: docker_version == '18.09'
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Add RHEL7 Extras repository
+  shell: yum-config-manager --enable "Red Hat Enterprise Linux Server 7 Extra(RPMs)"
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success 
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present

--- a/tasks/system/RedHat-7/main.yml
+++ b/tasks/system/RedHat-7/main.yml
@@ -1,0 +1,4 @@
+---
+- include_tasks: install_dependencies.yml
+- include_tasks: install_docker.yml
+  tags: [install_docker, destructive]

--- a/tasks/system/general/make_user.yml
+++ b/tasks/system/general/make_user.yml
@@ -11,10 +11,11 @@
 
 - name: Add group elastic
   group:
-    name: elastic
+    name:  "{{ item }}"
     state: present
   when: item not in ansible_facts.getent_group
   with_items:
+      - docker
       - elastic  
 
 - name: Add user elastic

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -1,0 +1,14 @@
+---
+docker_unit_after: "multi-user.target"
+docker_storage_driver: overlay2
+bootloader_update_command: grub2-mkconfig
+
+# Docker version mapping
+docker_version_map:
+  "18.09":
+    name: 'Docker-CE'
+    package: docker-ce-18.09.2
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    keys:
+      server: https://download.docker.com/linux/centos/gpg
+      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35

--- a/vars/os_RedHat_7.yml
+++ b/vars/os_RedHat_7.yml
@@ -1,0 +1,18 @@
+---
+docker_unit_after: "multi-user.target"
+docker_storage_driver: overlay2
+bootloader_update_command: grub2-mkconfig
+
+# Docker version mapping
+docker_version_map:
+  "1.13":
+    name: 'Docker'
+    package: docker-1.13.1
+    repo: rhui-REGION-rhel-server-extras/7Server/x86_64
+  "18.09":
+    name: 'Docker-CE'
+    package: docker-ce-18.09.2
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    keys:
+      server: https://download.docker.com/linux/centos/gpg
+      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35


### PR DESCRIPTION
Everything should be back to where it was while the repo was private. This is a continuation of PR8. 
This request "Maybe we can add a field to the docker_version_map for RHEL add_docker_repo or so that is used here as a when: add_docker_repo is defined. This way we would only need to maintain that logic in the version map instead of going back to this task for new versions that get added later...
What do you think?" will be worked on now.