### PR TITLE
Skip setup_xfc is lgv already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The following variables are avaible:
 - `docker_config`: If specified as a path to a docker config, copies it to the target hosts  
 - [Supported Docker Versions](https://elastic.co/en/cloud-enterprise/current/ece-prereqs-software.html)  
   - `docker_version`: Supported version on CentOS 7, Ubuntu (14.04LTS, 16.04LTS) and SLES 12 is 18.09, Supported version on RHEL7 is 1.13  
-
+- `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
+    - Default: false
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host
 - `adminconsole_root_password`: The adminconsole root password

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ ece_installer_url: "https://download.elastic.co/cloud/elastic-cloud-enterprise.s
 # Overall setup variables (like package versions)
 docker_version: "18.09"
 device_name: xvdb
+force_xfc: false

--- a/tasks/system/general/setup_xfs.yml
+++ b/tasks/system/general/setup_xfs.yml
@@ -19,12 +19,14 @@
     vg: lxc
     lv: swap
     size: "{{swap_size.stdout}}m"
+    force: true
 
 - name: Create data volume
   lvol:
     vg: lxc
     lv: data
     size: 100%FREE
+    force: true
 
 - name: Setup swap
   command: mkswap /dev/lxc/swap

--- a/tasks/system/main.yml
+++ b/tasks/system/main.yml
@@ -22,6 +22,7 @@
 - include_tasks: general/set_limits.yml
 - include_tasks: general/setup_xfs.yml
   tags: [setup_filesystem, destructive]
+  when: ansible_lvm['vgs']['lxc'] is not defined or force_xfc == true
 - include_tasks: general/update_grub_docker.yml
   tags: [setup_filesystem, destructive]
 - include_tasks: general/configure_docker.yml


### PR DESCRIPTION
Closes #14

When the lxc volume already exists we tried to recreate it. Since all sizes are relative, this is not idempotent. Therefore we skip the `setup_xfc` tasks when the lvm already exists. This behaiviour can be overwritten by setting `force_xfc: true`.