### PR TITLE
Add variable to define a local authorized_key file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The following variables are avaible:
   - `docker_version`: Supported version on CentOS 7, Ubuntu (14.04LTS, 16.04LTS) and SLES 12 is 18.09, Supported version on RHEL7 is 1.13  
 - `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
     - Default: false
+- `elastic_authorized_keys_file`: Defines a local path to an `authorized_keys` file that should be copied to the `elastic` user. If not set, the keys from the default user that is used with ansible will be copied over.
+
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host
 - `adminconsole_root_password`: The adminconsole root password

--- a/tasks/system/general/make_user.yml
+++ b/tasks/system/general/make_user.yml
@@ -41,13 +41,21 @@
     path: ~elastic/.ssh/authorized_keys
   register: es_authorized_keys 
 
+# If elastic_authorized_keys_file is not set, copy the authorized keys from default ansible user
 - name: Copy keys from default user to elastic user
   copy:
     src: "~{{ ansible_ssh_user }}/.ssh/authorized_keys"
     dest: ~elastic/.ssh/
     remote_src: yes
-  when: es_authorized_keys.stat.exists == false
+  when: es_authorized_keys.stat.exists == false and elastic_authorized_keys_file is not defined
   
+# If elastic_authorized_keys_file is defined, use that (local) path to copy the keys from 
+- name: Copy local keys to elastic user
+  copy:
+    src: "{{elastic_authorized_keys_file}}"
+    dest: ~elastic/.ssh/
+  when: es_authorized_keys.stat.exists == false and elastic_authorized_keys_file is defined
+
 - name: Set pwd policy
   lineinfile:
     path: /etc/sudoers.d/99-ece-users

--- a/tasks/system/general/make_user.yml
+++ b/tasks/system/general/make_user.yml
@@ -54,7 +54,7 @@
   copy:
     src: "{{elastic_authorized_keys_file}}"
     dest: ~elastic/.ssh/
-  when: es_authorized_keys.stat.exists == false and elastic_authorized_keys_file is defined
+  when: elastic_authorized_keys_file is defined
 
 - name: Set pwd policy
   lineinfile:


### PR DESCRIPTION
Closes #15

In case the elastic user should not inherit the `.ssh/authorized_keys` file from the "ansible default user", it is now possible to specify a local path to an `authorized_keys` file to be copied.