### PR TITLE
Disable firewalld on RHEL and CentOS

### DIFF
--- a/tasks/system/CentOS-7/main.yml
+++ b/tasks/system/CentOS-7/main.yml
@@ -1,3 +1,9 @@
 ---
+- name: Disable firewalld
+  systemd:
+    name: firewalld
+    state: stopped
+    enabled: no
+
 - include_tasks: install_docker.yml
   tags: [install_docker, destructive]

--- a/tasks/system/RedHat-7/main.yml
+++ b/tasks/system/RedHat-7/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Disable firewalld
+  systemd:
+    name: firewalld
+    state: stopped
+    enabled: no
+
 - include_tasks: install_dependencies.yml
 - include_tasks: install_docker.yml
   tags: [install_docker, destructive]


### PR DESCRIPTION
According to the official installation guide the firewalld has to be disabled (permanently) on RHEL and CentOS installations.