### PR TITLE
Do not use limits.conf to adjust system limits

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,6 @@ ece_installer_url: "https://download.elastic.co/cloud/elastic-cloud-enterprise.s
 docker_version: "18.09"
 device_name: xvdb
 force_xfc: false
+
+# Misc. variables (like sysctl settings file, etc.)
+system_limits_file: "/etc/security/limits.d/70-cloudenterprise.conf"

--- a/tasks/system/general/set_limits.yml
+++ b/tasks/system/general/set_limits.yml
@@ -5,6 +5,7 @@
     limit_type: "{{ item.limit_type }}"
     limit_item: "{{ item.limit_item }}"
     value: "{{ item.value }}"
+  dest: "{ system_limits_file }"
   with_items:
   - { domain: '*', limit_type: 'soft', limit_item: 'nofile', value: '1024000' }
   - { domain: '*', limit_type: 'hard', limit_item: 'nofile', value: '1024000' }


### PR DESCRIPTION
Setting resource limits in '/etc/security/limits.conf' is probably not ideal.
First of all they only apply to users logged in via PAM, but are ignored by system services - my reading is that since ECE is started via systemd and not interactively these will be ignored.
Secondly the configuration files in 'etc/security/limits.d' (generally) override any settings in this file, which might lead to all sorts of weird behaviour.

I've therefore changed the task to write the limits to a distinct configuration file and additionally parameterized the file name to use.