### PR TITLE
Handling of Docker 1.13 on RHEL systems

### DIFF
--- a/tasks/system/RedHat-7/install_docker.yml
+++ b/tasks/system/RedHat-7/install_docker.yml
@@ -15,6 +15,7 @@
   rpm_key:
     key: https://download.docker.com/linux/centos/gpg
     state: present
+  when: docker_version == '18.09'
 
 - name: Add docker repository
   yum_repository:

--- a/templates/docker1.13.conf
+++ b/templates/docker1.13.conf
@@ -1,0 +1,11 @@
+[Unit]
+Description=Docker Service
+After={{ docker_unit_after }}
+
+[Service]
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip=172.17.42.1/16"
+ExecStart=
+ExecStart=/usr/bin/dockerd $DOCKER_OPTS
+Restart=on-failure
+RestartSec=1s
+TimeoutSec=20


### PR DESCRIPTION
Elastic recommends using the RPMs provided by RedHat - currently Docker 1.13
The way the role is set up a separate configuration file for Docker is required - called 'docker1.13.conf' - although the contents are currently identical to 'docker18.09.conf'.
I've also added an additional 'when' clause to the 'install_docker.yml' script to only add the Docker repository key if version '18.09' is to be installed.

As a side note:
I think it's likely that a RedHat Satellite server will be used to provide packages (that is the case at our company) for installation. In that case adding the 'extras' repository is not necessary (and will probably fail). Making that task optional by adding a 'skip' variable might help (e.g. in the 'docker1.13.conf' file?).