### PR TITLE
Do not restart the docker service prior to reboot

### DIFF
--- a/tasks/system/general/configure_docker.yml
+++ b/tasks/system/general/configure_docker.yml
@@ -19,9 +19,9 @@
     path: /var/lib/docker
     state: absent
 
-- name: Reload systemd docker daemon
+- name: Reload systemd docker daemon and enable it
   systemd:
     name: docker
     enabled: yes
     daemon_reload: yes
-    state: restarted
+

--- a/tasks/system/general/configure_docker.yml
+++ b/tasks/system/general/configure_docker.yml
@@ -19,7 +19,7 @@
     path: /var/lib/docker
     state: absent
 
-- name: Reload systemd docker daemon and enable it
+- name: Docker daemon is enabled and systemd has read all changes
   systemd:
     name: docker
     enabled: yes


### PR DESCRIPTION
We ran into some sort of race condition on RHEL 7.6 where docker.service wasn't available after the reboot.
One of our Linux Admins suggested that restarting the daemon prior to rebooting the system is unnecessary - making sure the service is enabled ('enabled: true') and forcing systemd to load all the changes ('daemon_reload: yes') is sufficient.
Since the only distro available to me is RedHat i don't know if SuSE, CentOS or Ubuntu might also be affected by this.