### PR TITLE
Module ip_conntrack has to be loaded before changes are applied

### DIFF
--- a/tasks/system/general/sysctl_scripts.yml
+++ b/tasks/system/general/sysctl_scripts.yml
@@ -1,4 +1,9 @@
 ---
+- name: sysctl_scripts.yml || load ip_conntrack if needed
+  modprobe:
+    name: ip_conntrack
+    state: present
+
 - name: Create sysctl settings file
   file:
     path: "{{ sysctl_settings_file }}"
@@ -21,8 +26,3 @@
   -  { name: 'net.ipv4.tcp_keepalive_time', value: '1800' }
   -  { name: 'net.netfilter.nf_conntrack_tcp_timeout_established', value: '7200' }
   -  { name: 'net.netfilter.nf_conntrack_max', value: '262140' }
-
-- name: sysctl_scripts.yml || load ip_conntrack if needed
-  modprobe:
-    name: ip_conntrack
-    state: present


### PR DESCRIPTION
The 'ip_conntrack' module has to be loaded before changes are made to the network settings.
By using 'sysctl: set' every token will be validated and e.g. the setting
> name: 'net.netfilter.nf_conntrack_tcp_timeout_established', value: '7200'

will fail the task with
> sysctl: cannot stat /proc/sys/net/netfilter/nf_conntrack_tcp_timeout_established: No such file or directory

in case the module is not loaded.

There is an additional catch: modprobe will load the module , but it's not persistent over reboots.
Forcing the module to be loaded by putting a '.conf' file into '/etc/modules-load.d/' might be a good idea.