### PR TITLE
Adjustable memory settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following variables are avaible:
 - `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
     - Default: false
 - `elastic_authorized_keys_file`: Defines a local path to an `authorized_keys` file that should be copied to the `elastic` user. If not set, the keys from the default user that is used with ansible will be copied over.
+- `memory`: Defines the JVM heap size to be used for different services running in ece. See https://www.elastic.co/guide/en/cloud-enterprise/current/ece-heap.html for example values and [defaults/main.yml](defaults/main.yml) for the default values.
 
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,13 @@ force_xfc: false
 # Misc. variables (like sysctl settings file, etc.)
 sysctl_settings_file: "/etc/sysctl.d/70-cloudenterprise.conf"
 system_limits_file: "/etc/security/limits.d/70-cloudenterprise.conf"
+
+# Memory settings
+memory:
+  runner: 1G
+  allocator: 4G
+  proxy: 8G
+  zookeeper: 4G
+  director: 1G
+  constructor: 4G
+  adminconsole: 4G

--- a/tasks/bootstrap/main.yml
+++ b/tasks/bootstrap/main.yml
@@ -22,6 +22,10 @@
   shell: docker ps -a -f name=frc-runners-runner --format {%raw%}"{{.Image}}"{%endraw%}
   register: existing_runner
 
+- name: Create memory settings
+  set_fact:
+    memory_settings: ' {"runner":{"xms":"{{memory.runner}}","xmx":"{{memory.runner}}"},"proxy":{"xms":"{{memory.proxy}}","xmx":"{{memory.proxy}}"},"zookeeper":{"xms":"{{memory.zookeeper}}","xmx":"{{memory.zookeeper}}"},"director":{"xms":"{{memory.director}}","xmx":"{{memory.director}}"},"constructor":{"xms":"{{memory.constructor}}","xmx":"{{memory.constructor}}"},"admin-console":{"xms":"{{memory.adminconsole}}","xmx":"{{memory.adminconsole}}"}}'
+
 - name: Install Elastic Cloud Enterprise
   block:
     - include_tasks: primary/main.yml

--- a/tasks/bootstrap/primary/install_stack.yml
+++ b/tasks/bootstrap/primary/install_stack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Execute the primary installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }}
+  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}'
   become: yes
   become_method: sudo
   become_user: elastic

--- a/tasks/bootstrap/secondary/install_stack.yml
+++ b/tasks/bootstrap/secondary/install_stack.yml
@@ -20,7 +20,7 @@
   register: roles_token
 
 - name: Execute installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }}
+  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}'
   become: yes
   become_method: sudo
   become_user: elastic


### PR DESCRIPTION
Closes #22 

This PR introduces a new variable `memory`which defines the [JVM heap sizes](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-heap.html) of different services running in ECE.
`memory`is a simple dict that is then put into a json string to pass to the installer

```yaml
# Memory settings
memory:
  runner: 1G
  allocator: 4G
  proxy: 8G
  zookeeper: 4G
  director: 1G
  constructor: 4G
  adminconsole: 4G


- name: Create memory settings
  set_fact:
    memory_settings: ' {"runner":{"xms":"{{memory.runner}}","xmx":"{{memory.runner}}"},"proxy":{"xms":"{{memory.proxy}}","xmx":"{{memory.proxy}}"},"zookeeper":{"xms":"{{memory.zookeeper}}","xmx":"{{memory.zookeeper}}"},"director":{"xms":"{{memory.director}}","xmx":"{{memory.director}}"},"constructor":{"xms":"{{memory.constructor}}","xmx":"{{memory.constructor}}"},"admin-console":{"xms":"{{memory.adminconsole}}","xmx":"{{memory.adminconsole}}"}}'

```