### PR TITLE
Make sure to load overlay and ip_conntrack modules

### DIFF
--- a/tasks/system/general/kernel_modules.yml
+++ b/tasks/system/general/kernel_modules.yml
@@ -1,0 +1,8 @@
+---
+- name: Enable kernel modules
+  copy:
+    content: "{{item.kernel_module}}"
+    dest: "/etc/modules-load.d/{{item.name}}.conf"
+  with_items:
+  - { name: 'conntrack', kernel_module: 'ip_conntrack' }
+  - { name: 'overlay', kernel_module: 'overlay' }

--- a/tasks/system/main.yml
+++ b/tasks/system/main.yml
@@ -28,6 +28,7 @@
 - include_tasks: general/configure_docker.yml
   tags: [install_docker, destructive]
 - include_tasks: general/sysctl_scripts.yml
+- include_tasks: general/kernel_modules.yml
 
 - name: Reboot the machine with all defaults
   shell: sleep 2 && shutdown -r now "Reboot for changes to take effect"


### PR DESCRIPTION
Closes #29

Adds a new `kernel_,modules.yml` file to make sure kernel modules are loaded on every reboot.