### PR TITLE
Add support for ece support diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ The following variables are avaible:
 - `elastic_authorized_keys_file`: Defines a local path to an `authorized_keys` file that should be copied to the `elastic` user. If not set, the keys from the default user that is used with ansible will be copied over.
 - `memory`: Defines the JVM heap size to be used for different services running in ece. See https://www.elastic.co/guide/en/cloud-enterprise/current/ece-heap.html for example values and [defaults/main.yml](defaults/main.yml) for the default values.
 
+- `ece_supportdiagnostics_url`: THe location of the diagnostics tool. Can be a local file for offline installation.
+    - Default: `https://github.com/elastic/ece-support-diagnostics/archive/v1.1.tar.gz`
+- `ece_supportdiagnostics_result_path`: The localtion where to store the diagnostic bundles on ansible host.
+    - Default: `/tmp/ece-support-diagnostics`
+
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host
 - `adminconsole_root_password`: The adminconsole root password
@@ -94,6 +99,7 @@ The following tags are available to limit the execution, due to the nature of ta
     - `install_docker` If system tasks are executed, this determines if existing docker packages should get removed and the current, supported version should get installed and configured
 - `destructive` This tag indicates whether a task is potentially destructive, like removing packages or doing filesystem partitioning
 - `ece` Determines if Elastic Cloud Enterprise should get installed
+- `diagnostics` Determines if Elastic Cloud Enterprise Support Diagnostics should be downloaded and executed
 
 
 ## Examples and use cases

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,7 @@ memory:
   director: 1G
   constructor: 4G
   adminconsole: 4G
+
+# Elastic Cloud Enterprise - Support Diagnostics Settings
+ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.1.tar.gz"
+ece_supportdiagnostics_result_path: "/tmp/ece-support-diagnostics"

--- a/tasks/diagnostics/main.yml
+++ b/tasks/diagnostics/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Download ece support diagnostics
+  get_url:
+    url: "{{ ece_supportdiagnostics_url }}"
+    dest: /home/elastic/ece-support-diagnostics.tar.gz
+    mode: 0755
+
+- name: Unzip downloaded ece support diagnostics
+  unarchive:
+    src: /home/elastic/ece-support-diagnostics.tar.gz
+    dest: /home/elastic/ece-support-diagnostics
+    remote_src: yes
+
+- name: Run ece support diagnostics
+  script: /home/elastic/ece-support-diagnostics/diagnostics.sh
+
+- name: Download diagnostic bundles to ansible host and save under {{ ece_supportdiagnostics_result_path }}
+  fetch:
+    src: "/tmp/ece_diag-{{ ansible_eth0.ipv4.address }}-.tar.gz"
+    dest: "{{ ece_supportdiagnostics_result_path }}"

--- a/tasks/diagnostics/main.yml
+++ b/tasks/diagnostics/main.yml
@@ -1,18 +1,26 @@
 ---
+- name: Create path /tmp/elastic
+  local_action:
+    module: file
+    path: /tmp/elastic/ece-support-diagnostics
+    state: directory
+    mode: 0755
+
 - name: Download ece support diagnostics
-  get_url:
+  local_action:
+    module: get_url
     url: "{{ ece_supportdiagnostics_url }}"
-    dest: /home/elastic/ece-support-diagnostics.tar.gz
+    dest: /tmp/elastic/ece-support-diagnostics.tar.gz
     mode: 0755
 
 - name: Unzip downloaded ece support diagnostics
-  unarchive:
-    src: /home/elastic/ece-support-diagnostics.tar.gz
-    dest: /home/elastic/ece-support-diagnostics
-    remote_src: yes
+  local_action:
+    module: unarchive
+    src: /tmp/elastic/ece-support-diagnostics.tar.gz
+    dest: /tmp/elastic/
 
 - name: Run ece support diagnostics
-  script: /home/elastic/ece-support-diagnostics/diagnostics.sh
+  script: /tmp/elastic/ece-support-diagnostics-1.1/diagnostics.sh -s -d
 
 - name: Download diagnostic bundles to ansible host and save under {{ ece_supportdiagnostics_result_path }}
   fetch:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,3 +4,6 @@
 
 - include_tasks: bootstrap/main.yml
   tags: [ece]
+
+- include_tasks: diagnostics/main.yml
+  tags: [diagnostics]


### PR DESCRIPTION
PR for issue https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/38

The ansible role runs successfully until executing the diagnostics.sh - following steps could not be tested correctly because I currently don´t have an ECE running.

Following improvements could be done:
- Alter download url - currently hard coded to github download of v1.1
- v1.1 also hardcoded in task `Run ece support diagnostics`
- arguments passed to diagnostics.sh are also hardcoded