### PR TITLE
Fix ubuntu-xenial (docker-ce-cli and fstab)

### DIFF
--- a/tasks/system/general/setup_xfs.yml
+++ b/tasks/system/general/setup_xfs.yml
@@ -36,6 +36,12 @@
     fstype: xfs
     dev: /dev/lxc/data
 
+- name: remove automount of /dev/{{ device_name }}
+  lineinfile:
+    path:  /etc/fstab
+    state: absent
+    regexp: '^/dev/{{ device_name }}'
+
 - name: Add entries to fstab
   lineinfile:
     path: /etc/fstab
@@ -50,4 +56,4 @@
 - name: Enable all swap devices
   command: swapon -a
   args:
-    warn: no
+    warn: false

--- a/vars/os_Ubuntu_16.yml
+++ b/vars/os_Ubuntu_16.yml
@@ -6,7 +6,10 @@ bootloader_update_command: update-grub
 # Docker version mapping
 docker_version_map:
   "18.09":
-    package: docker-ce=5:18.09.2*
+    package:
+      - docker-ce=5:18.09.2*
+      - docker-ce-cli=5:18.09.2*
+      - containerd.io
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
ECE was installing on ubuntu-xenial but tests are failing because /dev/xvdb is not mounting (and so, `/mnt/data/docker` is on the root disk, instead than the extra disk).

/etc/fstab was looking like this on ubuntu:
```
LABEL=cloudimg-rootfs   /        ext4   defaults,discard        0 0
/dev/xvdb       /mnt    auto    defaults,nofail,x-systemd.requires=cloud-init.service,comment=cloudconfig       0       2
/dev/lxc/swap swap       swap  swap  0 0
/dev/lxc/data /mnt/data  xfs   defaults,pquota,prjquota,x-systemd.automount  0 0
```

So, I don't really understand why we have this extra `/dev/xvdb` on ubuntu. I suspect some aws magic (maybe a recent "change"), but now sure... anyway, the easy workaround is to remove this line. 