### PR TITLE
Fix docker install for ubuntu

### DIFF
--- a/vars/os_Ubuntu_16.yml
+++ b/vars/os_Ubuntu_16.yml
@@ -6,7 +6,10 @@ bootloader_update_command: update-grub
 # Docker version mapping
 docker_version_map:
   "18.09":
-    package: docker-ce=5:18.09.2*
+    package:
+      - docker-ce=5:18.09.2*
+      - docker-ce-cli=5:18.09.2*
+      - containerd.io
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
related to  https://github.com/elastic/cloud/issues/46198

https://github.com/elastic/cloud/pull/47911 was not enough to make ubuntu working: docker was not installing with the version set in params. Actually `docker-ce` package is installing with the right version requested (18.09 ) but not `docker-ce-cli` (19.x aka latest). 