### PR TITLE
Fix RHEL-7

### DIFF
--- a/tasks/system/RedHat-7/install_docker.yml
+++ b/tasks/system/RedHat-7/install_docker.yml
@@ -11,6 +11,10 @@
   delay: 30
   until: remove_packages is success
 
+- name: disable SELinux
+  selinux:
+    state: disabled
+
 - name: Add Docker GPG Key
   rpm_key:
     key: https://download.docker.com/linux/centos/gpg

--- a/tasks/system/RedHat-7/install_docker.yml
+++ b/tasks/system/RedHat-7/install_docker.yml
@@ -32,7 +32,7 @@
   until: repo_installed is success
 
 - name: Add RHEL7 Extras repository
-  shell: yum-config-manager --enable "Red Hat Enterprise Linux Server 7 Extra(RPMs)"
+  shell: yum-config-manager --enable "{{ docker_version_map[docker_version]['repo'] }}"
   register: repo_installed
   retries: 10
   delay: 30

--- a/tasks/system/RedHat-7/install_docker.yml
+++ b/tasks/system/RedHat-7/install_docker.yml
@@ -42,3 +42,10 @@
   package:
     name: "{{ docker_version_map[docker_version]['package'] }}"
     state: present
+
+- name: Verify that fs.may_detach_mounts is enabled
+  lineinfile:
+    path: /etc/sysctl.conf
+    regexp: '^fs.may_detach_mounts'
+    line: 'fs.may_detach_mounts = 1'
+    create: yes

--- a/tasks/system/general/configure_docker.yml
+++ b/tasks/system/general/configure_docker.yml
@@ -8,11 +8,38 @@
   file:
     path: /etc/systemd/system/docker.service.d
     state: directory
+  when: docker_version == '18.09'
 
 - name: Create service.d docker.conf
   template:
     src: docker{{ docker_version }}.conf
     dest: /etc/systemd/system/docker.service.d/docker.conf
+  when: docker_version == '18.09'
+
+- name: set docker storage options
+  lineinfile:
+    path: /etc/sysconfig/docker
+    regexp: "^OPTIONS='(.*)'"
+    line: "OPTIONS='-g /mnt/data/docker \\1'"
+    backrefs: yes
+    create: yes
+  when: docker_version == '1.13'
+
+- name: set docker network options
+  lineinfile:
+    path: /etc/sysconfig/docker-network
+    regexp: '^DOCKER_NETWORK_OPTIONS='
+    line: 'DOCKER_NETWORK_OPTIONS="--bip=172.17.42.1/16"'
+    create: yes
+  when: docker_version == '1.13'
+
+- name: set docker storage driver
+  lineinfile:
+    path: /etc/sysconfig/docker-storage-setup
+    regexp: '^DOCKER_NETWORK_OPTIONS='
+    line: 'STORAGE_DRIVER={{ docker_storage_driver }}'
+    create: yes
+  when: docker_version == '1.13'
 
 - name: Remove var/lib/docker
   file:

--- a/vars/os_RedHat_7.yml
+++ b/vars/os_RedHat_7.yml
@@ -7,8 +7,8 @@ bootloader_update_command: grub2-mkconfig
 docker_version_map:
   "1.13":
     name: 'Docker'
-    package: docker-1.13.1
-    repo: rhui-REGION-rhel-server-extras/7Server/x86_64
+    package: docker-2:1.13.1-109*
+    repo: "Red Hat Enterprise Linux*7*Extra*RPMs)"
   "18.09":
     name: 'Docker-CE'
     package: docker-ce-18.09.2


### PR DESCRIPTION
Related to https://github.com/elastic/cloud/issues/50009

**Yum REPO:** 
Docker 1.13 was not installing because (wrong repo for RHEL 7.7, different for <= 7.6)

**Docker service config:**
Docker conf in `/usr/lib/systemd/system/docker.service` does contain a specific conf for `docker-proxy` and `docker-runc`:
```
ExecStart=/usr/bin/dockerd-current \
          --add-runtime docker-runc=/usr/libexec/docker/docker-runc-current \
          --default-runtime=docker-runc \
          --authorization-plugin=rhel-push-plugin \
          --exec-opt native.cgroupdriver=systemd \
          --userland-proxy-path=/usr/libexec/docker/docker-proxy-current \
          --init-path=/usr/libexec/docker/docker-init-current \
          --seccomp-profile=/etc/docker/seccomp.json \
          $OPTIONS \
          $DOCKER_STORAGE_OPTIONS \
          $DOCKER_NETWORK_OPTIONS \
          $ADD_REGISTRY \
          $BLOCK_REGISTRY \
          $INSECURE_REGISTRY \
          $REGISTRIES
```

But, in `/etc/systemd/system/docker.service.d/docker.conf ` we are overriding this config:

```
Environment="DOCKER_OPTS=-H unix:///run/docker.sock --userland-proxy-path=/usr/libexec/docker/docker-proxy-current -g /mnt/data/docker --storage-driver=overlay2 --bip=172.17.42.1/16"
ExecStart=
ExecStart=/usr/bin/dockerd $DOCKER_OPTS
Restart=on-failure
```
According to the [doc](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configure-hosts-rhel-centos.html#ece_rhel_2), contrary to centos, we are not overriding the `ExecStart` entirely, but only the `OPTION` variable in `/etc/sysconfig/docker`.

**SELinux**
SELinux was blocking installation of ECE. According to [ECE doc](url), there is some specific config to make that working, but not documented. So I think the best is to treat this SELinux compatibility in an other GH issue. In the mean time, it's disabled for RHEL (ideally, I think we should come up with a playbook where we can parametrize if we enable SELinux or not)

