### PR TITLE
Fix playbook for CentOS 7

### DIFF
--- a/tasks/system/CentOS-7/install_Docker-CE.yml
+++ b/tasks/system/CentOS-7/install_Docker-CE.yml
@@ -1,0 +1,23 @@
+---
+- name: Add Docker GPG Key
+  rpm_key:
+    key: https://download.docker.com/linux/centos/gpg
+    state: present
+
+- name: Add docker repository
+  yum_repository:
+    name: "{{ docker_version_map[docker_version]['name'] }}"
+    description: "Docker repository"
+    file: docker-ce
+    baseurl: "{{ docker_version_map[docker_version]['repo'] }}"
+    enabled: yes
+    gpgcheck: no
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present

--- a/tasks/system/CentOS-7/install_Docker-CS.yml
+++ b/tasks/system/CentOS-7/install_Docker-CS.yml
@@ -1,0 +1,23 @@
+---
+- name: Add Docker GPG Key
+  rpm_key:
+    key: https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e
+    state: present
+
+- name: Add docker repository
+  yum_repository:
+    name: "{{ docker_version_map[docker_version]['name'] }}"
+    description: "Docker repository"
+    file: docker-ce
+    baseurl: "{{ docker_version_map[docker_version]['repo'] }}"
+    enabled: yes
+    gpgcheck: no
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present

--- a/tasks/system/CentOS-7/install_Docker-CS.yml
+++ b/tasks/system/CentOS-7/install_Docker-CS.yml
@@ -1,4 +1,8 @@
 ---
+- name: disable SELinux
+  selinux:
+    state: disabled
+
 - name: Add Docker GPG Key
   rpm_key:
     key: https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e

--- a/tasks/system/CentOS-7/install_docker.yml
+++ b/tasks/system/CentOS-7/install_docker.yml
@@ -11,25 +11,5 @@
   delay: 30
   until: remove_packages is success
 
-- name: Add Docker GPG Key
-  rpm_key:
-    key: https://download.docker.com/linux/centos/gpg
-    state: present
-
-- name: Add docker repository
-  yum_repository:
-    name: "{{ docker_version_map[docker_version]['name'] }}"
-    description: "Docker repository"
-    file: docker-ce
-    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
-    enabled: yes
-    gpgcheck: no
-  register: repo_installed
-  retries: 10
-  delay: 30
-  until: repo_installed is success
-
-- name: Install docker
-  package:
-    name: "{{ docker_version_map[docker_version]['package'] }}"
-    state: present
+- name: install specific version of docker
+  include_tasks: "install_{{ docker_version_map[docker_version]['name'] }}.yml"

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -7,7 +7,10 @@ bootloader_update_command: grub2-mkconfig
 docker_version_map:
   "18.09":
     name: 'Docker-CE'
-    package: docker-ce-18.09.2
+    package:
+      - docker-ce-18.09.2
+      - docker-ce-cli-18.09.2
+      - containerd.io
     repo: https://download.docker.com/linux/centos/docker-ce.repo
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -5,6 +5,10 @@ bootloader_update_command: grub2-mkconfig
 
 # Docker version mapping
 docker_version_map:
+  "1.13":
+    name: 'Docker-CS'
+    package: docker-1.13.1-108*
+    repo: https://packages.docker.com/1.13/yum/repo/main/centos/7
   "18.09":
     name: 'Docker-CE'
     package:

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -15,7 +15,7 @@ docker_version_map:
       - docker-ce-18.09.2
       - docker-ce-cli-18.09.2
       - containerd.io
-    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg
       id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35


### PR DESCRIPTION
Related to https://github.com/elastic/cloud/issues/50010

This will fix the following issues:
- `docker-ce-cli` is missing, and so it will install `docker-ce-cli` 19 (latest) and not 18 as requested
- add possibilty to install docker 1.13, without SELinux (for now): [ECE is supported by docker 1.13 on centos 7](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-prereqs-software.html)