### PR TITLE
Fix docker gpg repo key for Centos

### DIFF
--- a/tasks/system/CentOS-7/install_Docker-CE.yml
+++ b/tasks/system/CentOS-7/install_Docker-CE.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Docker GPG Key
   rpm_key:
-    key: https://download.docker.com/linux/centos/gpg
+    key: "{{ docker_version_map[docker_version]['keys']['server']}}"
     state: present
 
 - name: Add docker repository

--- a/tasks/system/CentOS-7/install_Docker-CS.yml
+++ b/tasks/system/CentOS-7/install_Docker-CS.yml
@@ -5,7 +5,7 @@
 
 - name: Add Docker GPG Key
   rpm_key:
-    key: https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e
+    key: "{{ docker_version_map[docker_version]['keys']['server']}}"
     state: present
 
 - name: Add docker repository

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -9,6 +9,8 @@ docker_version_map:
     name: 'Docker-CS'
     package: docker-1.13.1-108*
     repo: https://packages.docker.com/1.13/yum/repo/main/centos/7
+    keys:
+      server: https://packages.docker.com/1.13/yum/gpg
   "18.09":
     name: 'Docker-CE'
     package:
@@ -18,4 +20,3 @@ docker_version_map:
     repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg
-      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35


### PR DESCRIPTION
Since few days, we get this error: 
```
failed to fetch key at https://sks-keyservers.net/pks/lookup?op=get&search=0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e , error was: HTTP Error 502: Bad Gateway
```