### PR TITLE
Make docker bridge ip configurable. Change CenOS 7 play to match the way as it is done in RHEL 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following variables are avaible:
     - Default: false
 - `elastic_authorized_keys_file`: Defines a local path to an `authorized_keys` file that should be copied to the `elastic` user. If not set, the keys from the default user that is used with ansible will be copied over.
 - `memory`: Defines the JVM heap size to be used for different services running in ece. See https://www.elastic.co/guide/en/cloud-enterprise/current/ece-heap.html for example values and [defaults/main.yml](defaults/main.yml) for the default values.
+- `docker_bridge_ip`: Set the drocker bridge ip to avoid overlapping with host subnet or to match company guidelines
 
 - `fetch_diagnostics`: Determines if Elastic Cloud Enterprise Support Diagnostics should be downloaded and executed
 - `ece_supportdiagnostics_url`: THe location of the diagnostics tool. Can be a local file for offline installation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,6 @@ memory:
 ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.1.tar.gz"
 ece_supportdiagnostics_result_path: "/tmp/ece-support-diagnostics"
 fetch_diagnostics: false
+
+# General settings for docker environment
+docker_bridge_ip: "172.17.42.1/16"

--- a/tasks/base/CentOS-7/install_dependencies.yml
+++ b/tasks/base/CentOS-7/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install base dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - lvm2

--- a/tasks/base/CentOS-7/main.yml
+++ b/tasks/base/CentOS-7/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install lvm packages
-  yum:
-    name: 'lvm*'
-    state: present
-
 - name: Disable firewalld
   systemd:
     name: firewalld
@@ -32,6 +27,7 @@
     path: /etc/profile.d/path.sh
     line: "export PATH=$PATH:/usr/sbin"
     create: yes
-
+    
+- include_tasks: install_dependencies.yml
 - include_tasks: install_docker.yml
   tags: [install_docker, destructive]

--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -29,7 +29,7 @@
   lineinfile:
     path: /etc/sysconfig/docker-network
     regexp: '^DOCKER_NETWORK_OPTIONS='
-    line: 'DOCKER_NETWORK_OPTIONS="--bip=172.17.42.1/16"'
+    line: 'DOCKER_NETWORK_OPTIONS="--bip={{ docker_bridge_ip }}"'
     create: yes
   when: docker_version == '1.13'
 

--- a/templates/docker1.13.conf
+++ b/templates/docker1.13.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip=172.17.42.1/16"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure

--- a/templates/docker18.09.conf
+++ b/templates/docker18.09.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip=172.17.42.1/16"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure


### PR DESCRIPTION
This PR makes the docker bridge IP configurable to avoid overlapping with the host subnet or to give the possibility to mach companie guidelines on docker configuration requirements. 

Also added install_dependencies.yml to CentOS-7 installation play the same as it is already done in RedHat-7.

P.S. I already signed the Contributor Agreement. Anyway, I signed the agreement again. Hope this helps