### PR TITLE
Make docker bridge ip configurable, Install dependencies like in RedHat-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following variables are avaible:
 - `docker_config`: If specified as a path to a docker config, copies it to the target hosts  
 - [Supported Docker Versions](https://elastic.co/en/cloud-enterprise/current/ece-prereqs-software.html)  
   - `docker_version`: Supported version on CentOS 7, Ubuntu (14.04LTS, 16.04LTS) and SLES 12 is 18.09, Supported version on RHEL7 is 1.13  
+- `docker_bridge_ip `: The default IP of the docker bridge. Configurable to avoid overlapping with the current host subnet.
 - `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
     - Default: false
 - `elastic_authorized_keys_file`: Defines a local path to an `authorized_keys` file that should be copied to the `elastic` user. If not set, the keys from the default user that is used with ansible will be copied over.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,6 @@ memory:
 ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.1.tar.gz"
 ece_supportdiagnostics_result_path: "/tmp/ece-support-diagnostics"
 fetch_diagnostics: false
+
+# General settings for docker environment
+docker_bridge_ip: "172.17.42.1/16"

--- a/tasks/base/CentOS-7/install_dependencies.yml
+++ b/tasks/base/CentOS-7/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install base dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - lvm2

--- a/tasks/base/CentOS-7/main.yml
+++ b/tasks/base/CentOS-7/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Install lvm packages
-  yum:
-    name: 'lvm*'
-    state: present
-
 - name: Disable firewalld
   systemd:
     name: firewalld
@@ -33,5 +28,6 @@
     line: "export PATH=$PATH:/usr/sbin"
     create: yes
 
+- include_tasks: install_dependencies.yml
 - include_tasks: install_docker.yml
   tags: [install_docker, destructive]

--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -29,7 +29,7 @@
   lineinfile:
     path: /etc/sysconfig/docker-network
     regexp: '^DOCKER_NETWORK_OPTIONS='
-    line: 'DOCKER_NETWORK_OPTIONS="--bip=172.17.42.1/16"'
+    line: 'DOCKER_NETWORK_OPTIONS="--bip={{ docker_bridge_ip }}"'
     create: yes
   when: docker_version == '1.13'
 

--- a/templates/docker1.13.conf
+++ b/templates/docker1.13.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip=172.17.42.1/16"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure

--- a/templates/docker18.09.conf
+++ b/templates/docker18.09.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip=172.17.42.1/16"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g /mnt/data/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure


### PR DESCRIPTION
This PR allows to configure the docker bridge-ip using ansible vars. 
In some environments the default bridge-ip overlaps with the host subnet and may cause some issues with iptables. By setting the variable the IP can be changed.
Also updated README.md 