### PR TITLE
added ece_runner_id to allow runner_id to be set at install time

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The following variables are avaible:
     - Default: `https://github.com/elastic/ece-support-diagnostics/archive/v1.1.tar.gz`
 - `ece_supportdiagnostics_result_path`: The localtion where to store the diagnostic bundles on ansible host.
     - Default: `/tmp/ece-support-diagnostics`
+- `ece_runner_id`: Assigns an arbitrary ID to the host (runner) that you are installing Elastic Cloud Enterprise on
+    - Default: `host-ip`
 
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following variables are avaible:
 - `ece_supportdiagnostics_result_path`: The localtion where to store the diagnostic bundles on ansible host.
     - Default: `/tmp/ece-support-diagnostics`
 - `ece_runner_id`: Assigns an arbitrary ID to the host (runner) that you are installing Elastic Cloud Enterprise on
-    - Default: `host-ip`
+    - Default: `ansible_default_ipv4.address`
 
 If more hosts should join an Elastic Cloud Enterpise installation when a primary host was already installed previously there are two more variables that are required:
 - `primary_hostname`: The (reachable) hostname of the primary host

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""
 ece_installer_url: "https://download.elastic.co/cloud/elastic-cloud-enterprise.sh"
+ece_runner_id: "{{ ansible_default_ipv4.address }}"
 
 # Overall setup variables (like package versions)
 docker_version: "18.09"

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Execute the primary installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' {% if ece_runner_id is defined and ece_runner_id %}--runner-id {{ ece_runner_id }}{%endif%}
+  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }}
   become: yes
   become_method: sudo
   become_user: elastic

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Execute the primary installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}'
+  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' {% if ece_runner_id is defined and ece_runner_id %}--runner-id {{ ece_runner_id }}{%endif%}
   become: yes
   become_method: sudo
   become_user: elastic

--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -20,7 +20,7 @@
   register: roles_token
 
 - name: Execute installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' {% if ece_runner_id is defined and ece_runner_id %}--runner-id {{ ece_runner_id }}{%endif%}
+  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }}
   become: yes
   become_method: sudo
   become_user: elastic

--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -20,7 +20,7 @@
   register: roles_token
 
 - name: Execute installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}'
+  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' {% if ece_runner_id is defined and ece_runner_id %}--runner-id {{ ece_runner_id }}{%endif%}
   become: yes
   become_method: sudo
   become_user: elastic


### PR DESCRIPTION
Somehow managed to get in a pickle with branching and delete the original PR. Apologies @vaubarth ...

Hopefully addresses your concerns from https://github.com/elastic/ansible-elastic-cloud-enterprise/pull/65 