### PR TITLE
Make volume mounts idempotent by using ansible 'mount' module

### DIFF
--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -36,16 +36,23 @@
     fstype: xfs
     dev: /dev/lxc/data
 
-- name: Add entries to fstab
-  lineinfile:
-    path: /etc/fstab
-    line: "{{ item }}"
-  with_items:
-    - '/dev/lxc/swap swap       swap  swap  0 0'
-    - '/dev/lxc/data /mnt/data  xfs   defaults,pquota,prjquota,x-systemd.automount  0 0'
-
 - name: Mount /dev/lxc/data
-  command: mount /dev/lxc/data
+  mount:
+    path: /mnt/data
+    state: mounted
+    src: /dev/lxc/data
+    fstype: xfs
+    opts: "defaults,pquota,prjquota,x-systemd.automount"
+
+- name: Mount /dev/lxc/swap
+  mount:
+    src: "/dev/lxc/swap"
+    name: "swap"
+    fstype: "swap"
+    opts: "swap"
+    dump: "0"
+    passno: "0"
+    state: "present"
 
 - name: Enable all swap devices
   command: swapon -a


### PR DESCRIPTION
The way volume mounts are done currently causes an error when running the playbook a second time, because the volume is already mounted. Also, lines to `/etc/fstab` are added manually. This PR replaces the current approach with the Ansible `mount` module to make volume mounts idempotent. 
The mount module will create the entries in `/etc/fstab` as well as ensure the volume is mounted. If it is already mounted, Ansible will continue to execute the play.