### PR TITLE
Replace shell reboot command with Ansible reboot module

### DIFF
--- a/tasks/direct-install/main.yml
+++ b/tasks/direct-install/main.yml
@@ -2,16 +2,8 @@
 - include_tasks: setup_xfs.yml
 
 - name: Reboot the machine with all defaults
-  shell: sleep 2 && shutdown -r now "Reboot for changes to take effect"
-  async: 1
-  poll: 0
-  ignore_errors: true
-
-- name: Wait for the reboot to complete
-  wait_for_connection:
-    connect_timeout: 20
-    sleep: 5
-    delay: 5
-    timeout: 600
+  reboot:
+    msg: "Reboot for changes to take effect initiated by Ansible"
+    post_reboot_delay: 10
 
 - include_tasks: ../base/general/setup_mount_permissions.yml


### PR DESCRIPTION
Resolved conflict of previous PR (had commits from other PR still in the working branch). 
Replaced the 'reboot' shell command with the 'reboot' Ansible module, which is the recommended way to reboot servers in Ansible Playbooks