### PR TITLE
Add support for RHEL 8

### DIFF
--- a/tasks/base/RedHat-8/install_dependencies.yml
+++ b/tasks/base/RedHat-8/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install base dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - lvm2

--- a/tasks/base/RedHat-8/install_docker.yml
+++ b/tasks/base/RedHat-8/install_docker.yml
@@ -1,0 +1,61 @@
+---
+- name: Remove docker
+  package:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+    - docker
+  register: remove_packages
+  retries: 10
+  delay: 30
+  until: remove_packages is success
+
+- name: disable SELinux
+  selinux:
+    state: disabled
+
+- name: Add Docker GPG Key
+  rpm_key:
+    key: https://download.docker.com/linux/centos/gpg
+    state: present
+  when: docker_version == '19.03'
+
+- name: Add docker repository
+  yum_repository:
+    name: "{{ docker_version_map[docker_version]['name'] }}"
+    description: "Docker repository"
+    file: docker-ce
+    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    enabled: yes
+    gpgcheck: no
+  when: docker_version == '19.03'
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Add RHEL8 Extras repository
+  shell: dnf config-manager --add-repo="{{ docker_version_map[docker_version]['repo'] }}"
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Install containerd separately (CentOS 8).
+  package:
+    name: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
+    state: present
+  when: ansible_distribution_major_version | int == 8
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present
+
+- name: Verify that fs.may_detach_mounts is enabled
+  lineinfile:
+    path: /etc/sysctl.conf
+    regexp: '^fs.may_detach_mounts'
+    line: 'fs.may_detach_mounts = 1'
+    create: yes

--- a/tasks/base/RedHat-8/main.yml
+++ b/tasks/base/RedHat-8/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Disable firewalld
+  systemd:
+    name: firewalld
+    state: stopped
+    enabled: no
+  ignore_errors: true
+
+- include_tasks: install_dependencies.yml
+- include_tasks: install_docker.yml
+  tags: [install_docker, destructive]

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -1,0 +1,17 @@
+---
+docker_unit_after: "multi-user.target"
+docker_storage_driver: overlay2
+bootloader_update_command: grub2-mkconfig
+
+# Docker version mapping
+docker_version_map:
+  "19.03":
+    name: 'Docker-CE'
+    package:
+      - docker-ce-19.03.11
+      - docker-ce-cli-19.03.11
+      - containerd.io
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    keys:
+      server: https://download.docker.com/linux/centos/gpg
+      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35


### PR DESCRIPTION
RHEL8 has some caveats

* Works when `ansible_python_interpreter: /usr/libexec/platform-python`. No default python is installed in RHEL8 but the above link refers to python3
* docker packages are not made available and have to be fetched from CentOS repos
* containerd.io has to be installed before docker can be installed (managed by the playbook)