### PR TITLE
add mdadm to centos

### DIFF
--- a/tasks/base/CentOS-7/install_dependencies.yml
+++ b/tasks/base/CentOS-7/install_dependencies.yml
@@ -5,3 +5,4 @@
     state: present
   with_items:
   - lvm2
+  - mdadm

--- a/templates/format-drives.j2
+++ b/templates/format-drives.j2
@@ -42,10 +42,11 @@ else
   partprobe || true
   mdadm --create --verbose ${TARGET_DISK} --name=${TARGET_DISK##*/} --level=0 -c256 --raid-devices=${drive_count} ${drives}
 
-  echo DEVICE ${drives} | tee /etc/mdadm.conf
-  mdadm --detail --scan | tee -a /etc/mdadm.conf
-  blockdev --setra 65536 ${TARGET_DISK}
   [[ -e ${MDADM_CONF} ]] && cp ${MDADM_CONF} ${MDADM_CONF}.backup
+  install -Dv /dev/null ${MDADM_CONF}
+  echo DEVICE ${drives} | tee ${MDADM_CONF}
+  mdadm --detail --scan | tee -a ${MDADM_CONF}
+  blockdev --setra 65536 ${TARGET_DISK}
   mdadm --examine --scan | tee -a ${MDADM_CONF}
   echo $((30*1024)) > /proc/sys/dev/raid/speed_limit_min
 fi


### PR DESCRIPTION
Looks like `mdadm` is missing on centos. Not sure why, but it's missing...