### PR TITLE
Add CentOS 8 (with Docker 19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following variables are avaible:
     - Default: `https://download.elastic.co/cloud/elastic-cloud-enterprise.sh`
 - `docker_config`: If specified as a path to a docker config, copies it to the target hosts  
 - [Supported Docker Versions](https://elastic.co/en/cloud-enterprise/current/ece-prereqs-software.html)  
-  - `docker_version`: Supported version on CentOS 7, Ubuntu (14.04LTS, 16.04LTS) and SLES 12 is 18.09, Supported version on RHEL7 is 1.13  
+  - `docker_version`: Supported version on Centos 8, RHEL 8, Ubuntu 18 is 19.03, CentOS 7, Ubuntu (14.04LTS, 16.04LTS) and SLES 12 is 18.09, Supported version on RHEL7 is 1.13  
 - `docker_bridge_ip `: The default IP of the docker bridge. Configurable to avoid overlapping with the current host subnet.
 - `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
     - Default: false

--- a/tasks/base/CentOS-8/install_dependencies.yml
+++ b/tasks/base/CentOS-8/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install base dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - lvm2

--- a/tasks/base/CentOS-8/install_docker.yml
+++ b/tasks/base/CentOS-8/install_docker.yml
@@ -1,0 +1,54 @@
+---
+- name: Remove docker
+  package:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+    - docker
+  register: remove_packages
+  retries: 10
+  delay: 30
+  until: remove_packages is success
+
+- name: disable SELinux
+  selinux:
+    state: disabled
+
+- name: Add Docker GPG Key
+  rpm_key:
+    key: https://download.docker.com/linux/centos/gpg
+    state: present
+  when: docker_version == '19.03'
+
+- name: Add docker repository
+  yum_repository:
+    name: "{{ docker_version_map[docker_version]['name'] }}"
+    description: "Docker repository"
+    file: docker-ce
+    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    enabled: yes
+    gpgcheck: no
+  when: docker_version == '19.03'
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Install containerd separately (CentOS 8).
+  package:
+    name: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
+    state: present
+  when: ansible_distribution_major_version | int == 8
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present
+
+- name: Verify that fs.may_detach_mounts is enabled
+  lineinfile:
+    path: /etc/sysctl.conf
+    regexp: '^fs.may_detach_mounts'
+    line: 'fs.may_detach_mounts = 1'
+    create: yes

--- a/tasks/base/CentOS-8/main.yml
+++ b/tasks/base/CentOS-8/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Disable firewalld
+  systemd:
+    name: firewalld
+    state: stopped
+    enabled: no
+  ignore_errors: true
+
+- include_tasks: install_dependencies.yml
+- include_tasks: install_docker.yml
+  tags: [install_docker, destructive]

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -1,0 +1,17 @@
+---
+docker_unit_after: "multi-user.target"
+docker_storage_driver: overlay2
+bootloader_update_command: grub2-mkconfig
+
+# Docker version mapping
+docker_version_map:
+  "19.03":
+    name: 'Docker-CE'
+    package:
+      - docker-ce-19.03.12
+      - docker-ce-cli-19.03.12
+      - containerd.io
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    keys:
+      server: https://download.docker.com/linux/centos/gpg
+      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35

--- a/vars/os_RedHat_7.yml
+++ b/vars/os_RedHat_7.yml
@@ -11,7 +11,7 @@ docker_version_map:
     repo: "Red Hat Enterprise Linux*7*Extra*RPMs)"
   "18.09":
     name: 'Docker-CE'
-    package: docker-ce-18.09.2
+    package: docker-ce-18.09.3
     repo: https://download.docker.com/linux/centos/docker-ce.repo
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -8,8 +8,8 @@ docker_version_map:
   "19.03":
     name: 'Docker-CE'
     package:
-      - docker-ce-19.03.11
-      - docker-ce-cli-19.03.11
+      - docker-ce-19.03.12
+      - docker-ce-cli-19.03.12
       - containerd.io
     repo: https://download.docker.com/linux/centos/docker-ce.repo
     keys:

--- a/vars/os_Ubuntu_16.yml
+++ b/vars/os_Ubuntu_16.yml
@@ -1,6 +1,6 @@
 ---
 docker_unit_after: "multi-user.target"
-docker_storage_driver: aufs
+docker_storage_driver: overlay2
 bootloader_update_command: update-grub
 
 # Docker version mapping


### PR DESCRIPTION
Related to https://github.com/elastic/cloud/issues/63409

This is adding CentOS 8