### PR TITLE
Re-add setup_filesystem tag for xfs and mount operations

### DIFF
--- a/tasks/direct-install/main.yml
+++ b/tasks/direct-install/main.yml
@@ -1,5 +1,6 @@
 ---
 - include_tasks: setup_xfs.yml
+  tags: [setup_filesystem, destructive]
 
 - name: Reboot the machine with all defaults
   reboot:
@@ -7,3 +8,4 @@
     post_reboot_delay: 10
 
 - include_tasks: ../base/general/setup_mount_permissions.yml
+  tags: [setup_filesystem]


### PR DESCRIPTION
During migration to the new structure for vm images the tags for xfs and mount operations got lost.
This PR re-adds `setup_filesystem` to both tasks and also add `destructive` to `setup_xfs.yml`.

Closes #82