### PR TITLE
Fixing malformated file

### DIFF
--- a/tasks/base/general/setup_mount_permissions.yml
+++ b/tasks/base/general/setup_mount_permissions.yml
@@ -1,7 +1,7 @@
 ---
 - name: Change owner of {{ data_dir }}
   file:
-    path: {{ data_dir }}
+    path: "{{ data_dir }}"
     owner: elastic
     group: elastic
     mode: 0700


### PR DESCRIPTION
A quote was missing in `tasks/base/general/setup_mount_permissions.yml`