### PR TITLE
Update make_user.yml

### DIFF
--- a/tasks/base/general/make_user.yml
+++ b/tasks/base/general/make_user.yml
@@ -61,7 +61,17 @@
     line: 'elastic ALL=(ALL) NOPASSWD:ALL'
     state: present
     create: true
-
+    
+# Ensure /etc/cloud/cloud.cfg.d directories exist before trying to write files to them
+- name: Create cloud directories
+  file:
+    path: "/etc/{{ item }}"
+    state: directory
+  register: file_output
+  loop:
+    - cloud
+    - cloud/cloud.cfg.d
+    
 - name: set boot user
   template:
     src: elastic.cfg.j2


### PR DESCRIPTION
We need to ensure that /etc/cloud and /etc/cloud/cloud.cfg.d both exist before creating 00-elastic.cfg. If these directories do not exist ansible fails at the set boot user task.