### PR TITLE
Bump ECE default version to 2.6.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 2.4.3
+ece_version: 2.6.1
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
Related to https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/80 and bumping the default version to the very last version
﻿
