### PR TITLE
Install cloud-init by default

### DIFF
--- a/tasks/base/general/dependencies.yml
+++ b/tasks/base/general/dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install common base dependencies
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+  - cloud-init

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -15,6 +15,8 @@
     that: "docker_version in docker_version_map.keys()"
     msg: "Docker version must be one of {{ docker_version_map.keys() }}"
 
+- include_tasks: general/dependencies.yml
+
 - name: execute os specific tasks
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}/main.yml"
 


### PR DESCRIPTION
Fixing https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/62

Cloud-init is required by this ansible playbooks and failed if not pre-installed. Let's install it  if it was not already the case