### PR TITLE
Fix task copying docker config

### DIFF
--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -8,13 +8,13 @@
   file:
     path: /etc/systemd/system/docker.service.d
     state: directory
-  when: docker_version == '18.09'
+  when: docker_version != '1.13'
 
 - name: Create service.d docker.conf
   template:
     src: docker{{ docker_version }}.conf
     dest: /etc/systemd/system/docker.service.d/docker.conf
-  when: docker_version == '18.09'
+  when: docker_version != '1.13'
 
 - name: set docker storage options
   lineinfile:


### PR DESCRIPTION
Related to https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/100

When trying to install with `docker_version: 19.03` the docker config file is not copied over, resulting with not using the secondary disk as docker storage
