### PR TITLE
Fix MDADM on reboot

### DIFF
--- a/tasks/base/CentOS-8/install_dependencies.yml
+++ b/tasks/base/CentOS-8/install_dependencies.yml
@@ -5,3 +5,4 @@
     state: present
   with_items:
   - lvm2
+  - mdadm

--- a/templates/format-drives.j2
+++ b/templates/format-drives.j2
@@ -44,8 +44,6 @@ else
 
   [[ -e ${MDADM_CONF} ]] && cp ${MDADM_CONF} ${MDADM_CONF}.backup
   install -Dv /dev/null ${MDADM_CONF}
-  echo DEVICE ${drives} | tee ${MDADM_CONF}
-  mdadm --detail --scan | tee -a ${MDADM_CONF}
   blockdev --setra 65536 ${TARGET_DISK}
   mdadm --examine --scan | tee -a ${MDADM_CONF}
   echo $((30*1024)) > /proc/sys/dev/raid/speed_limit_min


### PR DESCRIPTION
As explained in https://github.com/elastic/sdh-cloud/issues/11718 `mdadm` is ignored when rebooting.
In order to reproduce the issue you need at least two secondary disks, with Centos 

I'll test this PR by creating new AMIs with this PR

Please note that this does not have any impact on ansible-playbook direct install mode since we are not currently supporting more than one secondary disk (configured with `device_name`)