### PR TITLE
Fixed link for "small playbook"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role for installing [Elastic Cloud Enterprise](https://www.elastic.co/pr
 
 ## Contents of this role
 
-A minimal example of a [small playbook](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-topology-example1.html) might look like this:
+A minimal example of a [small playbook](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-install-small-cloud.html) might look like this:
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In order to use this ansible playbook for building a VM image, the following tag
 
 ### Medium sized first installation of Elastic Cloud Enterprise
 
-This example installs Elastic Cloud Enterprise as detailed in "A medium installation with separate management services" [in the official documentation](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-topology-example2.html) and brings you up to *step 5 - Modify the first host you installed Elastic Cloud Enterprise on*
+This example installs Elastic Cloud Enterprise as detailed in "A medium installation with separate management services" [in the official documentation](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-install-medium-cloud.html) and brings you up to *step 5 - Modify the first host you installed Elastic Cloud Enterprise on*
 
 `site.yml`:
 ```yaml


### PR DESCRIPTION
The small and medium playbook link were causing a 404's as the pages were moved and do now live in a different place on /current/.