### PR TITLE
Bump SLES to SP5 with docker 19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,27 +32,16 @@ Inside this file at least the following needs to be specified (example from `var
 
 ```yaml
 ---
-# The following variables are used to populate templates/docker18.09.conf for the sysctl configuration
-docker_unit_after: "network.target docker.socket" # Goes into "[Unit] After=", e.g. 
-docker_storage_driver: overlay # The storage driver to use with docker
+# The following variables are used to populate templates/docker19.03.conf for the sysctl configuration
+---
+docker_unit_after: "network.target docker.socket"
+docker_storage_driver: overlay
+bootloader_update_command: update-bootloader
 
-# The command to be run to update the bootloader
-bootloader_update_command: # e.g. update-bootloader on SLES
-
-# The docker version mapping is used to easily support multiple docker versions
+# Docker version mapping
 docker_version_map:
-  # The version of docker to be installed, this value is referenced in defaults/main.yml (e.g. docker_version: "18.09")
-  "18.09": 
-    # The package name to be installed for this version
-    package: docker-18.09.1_ce 
-    # The repository that needs to be added for the docker package
-    repo: https://download.opensuse.org/repositories/Virtualization:containers/SLE_12_SP3/ 
-    name: Virtualization:containers # The name of the repository, if one is required
-    keys:
-      # The url from where to fetch the key for the repositry
-      server: http://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/repodata/repomd.xml.key
-      # The id of the key
-      id:
+  "19.03":
+    package: docker-19.03.14_ce
 ```
 
 See `vars/os_Ubuntu_16.yml` as an example.

--- a/tasks/base/SLES-12/install_docker.yml
+++ b/tasks/base/SLES-12/install_docker.yml
@@ -12,35 +12,6 @@
   delay: 30
   until: remove_packages is success
 
-- name: Add docker repository
-  zypper_repository:
-    name: "{{ docker_version_map[docker_version]['name'] }}"
-    repo: "{{ docker_version_map[docker_version]['repo'] }}"
-    state: present
-    overwrite_multiple : true
-  register: repo_installed
-  retries: 10
-  delay: 30
-  until: repo_installed is success
-
-- name: Add docker repository key
-  command: "rpm --import '{{ docker_version_map[docker_version]['keys']['server'] }}'"
-  register: key_installed
-  retries: 10
-  delay: 30
-  until: key_installed is success
-  args:
-    warn: false
-
-- name: Reload repositories
-  command: "zypper --gpg-auto-import-keys refresh"
-  register: repo_reloaded
-  retries: 10
-  delay: 30
-  until: repo_reloaded is success
-  args:
-    warn: false
-
 - name: Install docker
   command: "zypper install -y --force-resolution --replacefiles {{ docker_version_map[docker_version]['package'] }}"
   args:

--- a/vars/os_SLES_12.yml
+++ b/vars/os_SLES_12.yml
@@ -5,10 +5,5 @@ bootloader_update_command: update-bootloader
 
 # Docker version mapping
 docker_version_map:
-  "18.09":
-    package: docker-18.09.7_ce-98.43.1
-    repo: https://download.opensuse.org/repositories/Virtualization:containers/SLE_12_SP3/
-    name: Virtualization:containers
-    keys:
-      server: http://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP3/repodata/repomd.xml.key
-      id:
+  "19.03":
+    package: docker-19.03.14_ce


### PR DESCRIPTION
Closes https://github.com/elastic/cloud/issues/73576

This is bumping SLES_12 to **SP5** and **docker 19**