### PR TITLE
Disabling dockerd's icc for all versions

### DIFF
--- a/templates/docker1.13.conf
+++ b/templates/docker1.13.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure

--- a/templates/docker18.09.conf
+++ b/templates/docker18.09.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure

--- a/templates/docker19.03.conf
+++ b/templates/docker19.03.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }}"
+Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure


### PR DESCRIPTION
In order to align ansible scripts with the [documentation](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configure-hosts-ubuntu-cloud.html), we need to disable icc everywhere. 