### PR TITLE
Preventing errors with LVM when re-running the playbook

### DIFF
--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -29,13 +29,10 @@
     shrink: no
     force: true
 
-- name: Disable all swap devices
-  command: swapoff -a
-  args:
-    warn: no
-
-- name: Setup swap
-  command: mkswap /dev/lxc/swap
+- name: Create swap filesystem on /dev/lxc/swap
+  filesystem:
+    fstype: swap
+    dev: /dev/lxc/swap
 
 - name: Create xfs filesystem on /dev/lxc/data
   filesystem:

--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -26,7 +26,13 @@
     vg: lxc
     lv: data
     size: 100%FREE
+    shrink: no
     force: true
+
+- name: Disable all swap devices
+  command: swapoff -a
+  args:
+    warn: no
 
 - name: Setup swap
   command: mkswap /dev/lxc/swap


### PR DESCRIPTION
This PR solves issues with LVM when re-running the playbook after a failed run, when external disk is already formatted and swap partition is already created:

```
TASK [ansible-elastic-cloud-enterprise : Create data volume] ***************************************************************
fatal: [host1]: FAILED! => {"changed": false, "msg": "Sorry, no shrinking of data to 0 permitted."}
```

```
TASK [ansible-elastic-cloud-enterprise : Setup swap] ***********************************************************************
fatal: [host1]: FAILED! => {"changed": true, "cmd": ["mkswap", "/dev/lxc/swap"], "delta": "0:00:00.004355", "end": "2021-03-15 17:57:19.994434", "msg": "non-zero return code", "rc": 1, "start": "2021-03-15 17:57:19.990079", "stderr": "mkswap: error: /dev/lxc/swap is mounted; will not make swapspace", "stderr_lines": ["mkswap: error: /dev/lxc/swap is mounted; will not make swapspace"], "stdout": "", "stdout_lines": []}
```