### PR TITLE
Use RHEL/CentOS 8 specific repository for docker-ce

### DIFF
--- a/tasks/base/CentOS-8/install_docker.yml
+++ b/tasks/base/CentOS-8/install_docker.yml
@@ -35,12 +35,6 @@
   delay: 30
   until: repo_installed is success
 
-- name: Install containerd separately (CentOS 8).
-  package:
-    name: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
-    state: present
-  when: ansible_distribution_major_version | int == 8
-
 - name: Install docker
   package:
     name: "{{ docker_version_map[docker_version]['package'] }}"

--- a/tasks/base/CentOS-8/install_docker.yml
+++ b/tasks/base/CentOS-8/install_docker.yml
@@ -26,7 +26,7 @@
     name: "{{ docker_version_map[docker_version]['name'] }}"
     description: "Docker repository"
     file: docker-ce
-    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    baseurl: https://download.docker.com/linux/centos/8/x86_64/stable
     enabled: yes
     gpgcheck: no
   when: docker_version == '19.03'

--- a/tasks/base/RedHat-8/install_docker.yml
+++ b/tasks/base/RedHat-8/install_docker.yml
@@ -42,12 +42,6 @@
   delay: 30
   until: repo_installed is success
 
-- name: Install containerd separately (CentOS 8).
-  package:
-    name: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
-    state: present
-  when: ansible_distribution_major_version | int == 8
-
 - name: Install docker
   package:
     name: "{{ docker_version_map[docker_version]['package'] }}"

--- a/tasks/base/RedHat-8/install_docker.yml
+++ b/tasks/base/RedHat-8/install_docker.yml
@@ -26,7 +26,7 @@
     name: "{{ docker_version_map[docker_version]['name'] }}"
     description: "Docker repository"
     file: docker-ce
-    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    baseurl: https://download.docker.com/linux/centos/8/x86_64/stable
     enabled: yes
     gpgcheck: no
   when: docker_version == '19.03'

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -6,7 +6,7 @@ bootloader_update_command: grub2-mkconfig
 # Docker version mapping
 docker_version_map:
   "19.03":
-    name: 'Docker-CE'
+    name: 'docker-ce-stable'
     package:
       - docker-ce-19.03.13
       - docker-ce-cli-19.03.13

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -6,7 +6,7 @@ bootloader_update_command: grub2-mkconfig
 # Docker version mapping
 docker_version_map:
   "19.03":
-    name: 'Docker-CE'
+    name: 'docker-ce-stable'
     package:
       - docker-ce-19.03.13
       - docker-ce-cli-19.03.13


### PR DESCRIPTION
Hi,

since Docker already provides Builds for CentOS/RHEL 8 this PR changes the Repository URL to the EL 8 repo. During my tests I also discovered two additional things:

- containerd.io is a dependency of docker-ce (verified on RHEL 8 system)
- The installation of EL 7 docker-ce version on EL 8 fails due to unresolved dependencies -> ` "msg": "Depsolve Error occured: \n Problem: package docker-ce-3:19.03.13-3.el7.x86_64 requires containerd.io >= 1.2.2-3, but none of the providers can be installed...`

So I also removed the step do install containerd.io separately

Regards,
Alex