### PR TITLE
Bump ECE version to 2.10.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 2.9.2
+ece_version: 2.10.0
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
https://www.elastic.co/guide/en/cloud-enterprise/current/ece-release-notes-2.10.0.html