### PR TITLE
Pin containerd for centos and ubuntu

### DIFF
--- a/tasks/base/CentOS-8/install_dependencies.yml
+++ b/tasks/base/CentOS-8/install_dependencies.yml
@@ -6,3 +6,4 @@
   with_items:
   - lvm2
   - mdadm
+  - iptables

--- a/tasks/base/CentOS-8/install_docker.yml
+++ b/tasks/base/CentOS-8/install_docker.yml
@@ -26,20 +26,13 @@
     name: "{{ docker_version_map[docker_version]['name'] }}"
     description: "Docker repository"
     file: docker-ce
-    baseurl: https://download.docker.com/linux/centos/7/x86_64/stable
+    baseurl: "{{ docker_version_map[docker_version]['repo'] }}"
     enabled: yes
     gpgcheck: no
-  when: docker_version == '19.03'
   register: repo_installed
   retries: 10
   delay: 30
   until: repo_installed is success
-
-- name: Install containerd separately (CentOS 8).
-  package:
-    name: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
-    state: present
-  when: ansible_distribution_major_version | int == 8
 
 - name: Install docker
   package:

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -8,9 +8,9 @@ docker_version_map:
   "18.09":
     name: 'Docker-CE'
     package:
-      - docker-ce-18.09.2
-      - docker-ce-cli-18.09.2
-      - containerd.io
+      - docker-ce-18.09.9
+      - docker-ce-cli-18.09.9
+      - containerd.io-1.4.3
     repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -8,10 +8,10 @@ docker_version_map:
   "19.03":
     name: 'Docker-CE'
     package:
-      - docker-ce-19.03.13
-      - docker-ce-cli-19.03.13
-      - containerd.io
-    repo: https://download.docker.com/linux/centos/docker-ce.repo
+      - docker-ce-19.03.15
+      - docker-ce-cli-19.03.15
+      - containerd.io-1.4.3
+    repo: https://download.docker.com/linux/centos/8/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg
       id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35

--- a/vars/os_Ubuntu_16.yml
+++ b/vars/os_Ubuntu_16.yml
@@ -7,9 +7,9 @@ bootloader_update_command: update-grub
 docker_version_map:
   "18.09":
     package:
-      - docker-ce=5:18.09.2*
-      - docker-ce-cli=5:18.09.2*
-      - containerd.io
+      - docker-ce=5:18.09.9*
+      - docker-ce-cli=5:18.09.9*
+      - containerd.io=1.4.3-1*
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg

--- a/vars/os_Ubuntu_18.yml
+++ b/vars/os_Ubuntu_18.yml
@@ -7,9 +7,9 @@ bootloader_update_command: update-grub
 docker_version_map:
   "19.03":
     package:
-      - docker-ce=5:19.03.13*
-      - docker-ce-cli=5:19.03.13*
-      - containerd.io
+      - docker-ce=5:19.03.15*
+      - docker-ce-cli=5:19.03.15*
+      - containerd.io=1.4.3-1*
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
Closing https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/121 

Also for some reason, like for [rhel-8](https://github.com/elastic/ansible-elastic-cloud-enterprise/pull/98) , I needed to add iptable for centos-8