### PR TITLE
[SELinux] Try ECE with SELinux enabled on the host system

### DIFF
--- a/tasks/base/CentOS-8/install_docker.yml
+++ b/tasks/base/CentOS-8/install_docker.yml
@@ -13,13 +13,13 @@
 
 - name: disable SELinux
   selinux:
-    state: disabled
+    state: enforcing
 
 - name: Add Docker GPG Key
   rpm_key:
     key: https://download.docker.com/linux/centos/gpg
     state: present
-  when: docker_version == '19.03'
+  when: docker_version == '20.10'
 
 - name: Add docker repository
   yum_repository:

--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -5,12 +5,12 @@ bootloader_update_command: grub2-mkconfig
 
 # Docker version mapping
 docker_version_map:
-  "18.09":
+  "20.10":
     name: 'Docker-CE'
     package:
-      - docker-ce-18.09.9
-      - docker-ce-cli-18.09.9
-      - containerd.io-1.4.3
+      - docker-ce-20.10.7
+      - docker-ce-cli-20.10.7
+      - containerd.io-1.4.9
     repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -5,12 +5,12 @@ bootloader_update_command: grub2-mkconfig
 
 # Docker version mapping
 docker_version_map:
-  "19.03":
+  "20.10":
     name: 'Docker-CE'
     package:
-      - docker-ce-19.03.15
-      - docker-ce-cli-19.03.15
-      - containerd.io-1.4.3
+      - docker-ce-20.10.7
+      - docker-ce-cli-20.10.7
+      - containerd.io-1.4.9
     repo: https://download.docker.com/linux/centos/8/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_Ubuntu_18.yml
+++ b/vars/os_Ubuntu_18.yml
@@ -5,11 +5,11 @@ bootloader_update_command: update-grub
 
 # Docker version mapping
 docker_version_map:
-  "19.03":
+  "20.10":
     package:
-      - docker-ce=5:19.03.15*
-      - docker-ce-cli=5:19.03.15*
-      - containerd.io=1.4.3-1*
+      - docker-ce=5:20.10.7*
+      - docker-ce-cli=5:20.10.7*
+      - containerd.io=1.4.9-1*
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
Description: This PR enables testing with SELinux enabled.

It also bumps the Docker version across various supported operating systems.