### PR TITLE
Update default ECE version to 2.11.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 2.10.1
+ece_version: 2.11.0
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""
@@ -27,7 +27,7 @@ memory:
   adminconsole: 4G
 
 # Elastic Cloud Enterprise - Support Diagnostics Settings
-ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.2.tar.gz"
+ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.3.tar.gz"
 ece_supportdiagnostics_result_path: "/tmp/ece-support-diagnostics"
 fetch_diagnostics: false
 


### PR DESCRIPTION
This updates the default ECE version to 2.11.0 and bumps the support diagnostics version to 1.3. While v2.0.1 is available, there are breaking changes which have not been tested in the context of this playbook.