### PR TITLE
Bumpt ECE version to 2.12.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 2.11.0
+ece_version: 2.12.0
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
ECE 2.12.0 has been released, we can bump the default version here