### PR TITLE
Add tag for task which change filesystem permissions

### DIFF
--- a/tasks/direct-install/main.yml
+++ b/tasks/direct-install/main.yml
@@ -9,4 +9,4 @@
   tags: [setup_filesystem]
 
 - include_tasks: ../base/general/setup_mount_permissions.yml
-  tags: [setup_filesystem]
+  tags: [setup_filesystem, setup_fs_permissions]


### PR DESCRIPTION
This PR adds an extra tag for an invocation of `setup_mount_permissions.yml` to be able to skip it with `--skip-tags setup_fs_permissions`