### PR TITLE
Supporting allocator tags

### DIFF
--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -19,9 +19,18 @@
     body: '{ "persistent": false, "roles": {{ ece_roles }} }'
   register: roles_token
 
-- name: Execute installation
+- name: Execute installation - no allocator-tags
   shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --host-storage-path {{ data_dir }}/elastic --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }}
   become: yes
   become_method: sudo
   become_user: elastic
   register: installation
+  when: allocator_tags is undefined
+
+- name: Execute installation - with allocator-tags
+  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --host-storage-path {{ data_dir }}/elastic --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }} --allocator-tags {{ allocator_tags }}
+  become: yes
+  become_method: sudo
+  become_user: elastic
+  register: installation
+  when: allocator_tags is defined


### PR DESCRIPTION
In our setup we depend on allocator tags, so we have done a simple extension of `secondary/install_stack.yml`

It's a primitive solution because it looks only if an allocator tag is defined in a variable, not if it is actually an allocator being created. But it works for us :-)

We intend to use the Ansible role to rebuild the hosts (terraform taint + apply) at a regular interval, instead of doing OS upgrades on them. For this automation adding the tags at creation time (based on the inventory) is very useful to us.

Maybe this PR is not the right way to do it - we just want to open up the discussion...