### PR TITLE
Allow allocator capacity configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following variables are avaible:
     - Default: `/mnt/data`
 - `ece_roles`: Elastic Cloud Enterprise roles that successive hosts should assume
     - Default: [director, coordinator, proxy, allocator]
+- `capacity`: [Amount of memory to grant to the allocator](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-capacity.html#ece-alloc-memory)
+    - Default: left empty, installer default behavior will be applied
 - `availability_zone`: The availability zone this group of hosts belongs to
 - `ece_version`: The Elastic Cloud Enterprise version that should get installed
     - Default: 2.8.1

--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -4,6 +4,10 @@
     ece_roles: [director, coordinator, proxy, allocator]
   when: ece_roles is undefined
 
+- name: Set empty capacity if not defined
+  set_fact:
+    capacity: "{{ capacity | default('') }}"
+
 - name: Get the roles token
   uri:
     url: "https://{{primary_hostname}}:12443/api/v1/platform/configuration/security/enrollment-tokens"
@@ -20,7 +24,7 @@
   register: roles_token
 
 - name: Execute installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --host-storage-path {{ data_dir }}/elastic --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }}
+  shell: /home/elastic/elastic-cloud-enterprise.sh --coordinator-host {{ primary_hostname }} --roles-token '{{ roles_token.json.token }}' --roles '{{ ece_roles | join(',') }}' --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }}  --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --host-storage-path {{ data_dir }}/elastic --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }} {{ '--capacity ' + capacity if capacity }}
   become: yes
   become_method: sudo
   become_user: elastic


### PR DESCRIPTION
Until now, one had to manually override the Ansible task to use `--capacity`. This PR exposes a new `capacity` parameter that does just that. If left empty, the old behavior is used.