### PR TITLE
RHEL-based distributions grub.cfg are not updated

### DIFF
--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -1,7 +1,7 @@
 ---
 docker_unit_after:  "network.target docker.socket"
 docker_storage_driver: overlay2
-bootloader_update_command: grub2-mkconfig
+bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 
 # Docker version mapping

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -1,7 +1,7 @@
 ---
 docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
-bootloader_update_command: grub2-mkconfig
+bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 
 # Docker version mapping

--- a/vars/os_RedHat_7.yml
+++ b/vars/os_RedHat_7.yml
@@ -1,7 +1,7 @@
 ---
 docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
-bootloader_update_command: grub2-mkconfig
+bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 
 # Docker version mapping

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -1,7 +1,7 @@
 ---
 docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
-bootloader_update_command: grub2-mkconfig
+bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 
 # Docker version mapping


### PR DESCRIPTION
Hi team, 

Found out that grub2-mkconfig is not a direct equivalent to update-grub on Debian-based systems :) 

This is what update-grub actually does: 
```
cat /usr/sbin/update-grub
#!/bin/sh
set -e
exec grub-mkconfig -o /boot/grub/grub.cfg "$@"
```
So just executing grub2-mkconfig on RHEL-based distributions outputs the contents to stdout and that's it...

I'm using the symlink in `/etc` I verified its existence in CentOs 7 and RHEL 8 so I believe CentOS 8 and RHEL7 should work the same. It's also in the product [documentation](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configure-hosts-rhel-centos-cloud.html#ece-supported-kernel-rhel-cloud)


In the current state, this playbook does not configure any RHEL system properly so I believe this fix is rather urgent. 

Thank you.