### PR TITLE
Docker listen to /var/run/docker.sock

### DIFF
--- a/templates/docker.conf
+++ b/templates/docker.conf
@@ -3,7 +3,7 @@ Description=Docker Service
 After={{ docker_unit_after }}
 
 [Service]
-Environment="DOCKER_OPTS=-H unix:///run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false"
+Environment="DOCKER_OPTS=-H unix:///var/run/docker.sock -g {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure


### PR DESCRIPTION
According to [ECE installer](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-installation-script.html) and our test suite, we should default to `/var/run/docker.sock` instead of `/run/docker.sock`.

NB: on some OS, we force docker.service to listen on `/run/docker.sock` while `docker.socket` service listen on `/var/run/docker.sock`