### PR TITLE
Bump default ECE to 3.2.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 3.1.1
+ece_version: 3.2.1
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
ECE 3.2.1 was just released, update the default version to be just that. 