### PR TITLE
Variable to copy installer script instead of downloading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ The following variables are avaible:
     - Default: docker.elastic.co
 - `ece_docker_repository`: The docker repository in the given registry. This is only relevant if you have a private mirror
     - Default: cloud-enterprise
-- `ece_installer_url`: The location of the installation script. Can be a local file for offline installation.
+- `ece_installer_url`: The url of the installation script to download.
     - Default: `https://download.elastic.co/cloud/elastic-cloud-enterprise.sh`
+    - This will use the local script if existing in `/home/elastic/elastic-cloud-enterprise.sh`
+- `ece_installer_path`: The location of the installation script on the controller machine. It will be copied to remote host. 
+    - Default: left empty, it will download it from internet (cf. `ece_installer_url`)
 - `docker_config`: If specified as a path to a docker config, copies it to the target hosts
 - [Supported Docker Versions](https://www.elastic.co/guide/en/cloud-enterprise/2.7/ece-software-prereq.html#ece-linux-docker)
   - `docker_version`: Last supported version on Centos 7/8 and RHEL 7/8 is 20.0, Ubuntu 16, Ubuntu 18 and SLES 12 is 19.03.

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -1,9 +1,17 @@
 ---
+- name: Copy ece installer
+  copy:
+    src: "{{ ece_installer_path }}"
+    dest: /home/elastic/elastic-cloud-enterprise.sh
+    mode: 0755
+  when: ece_installer_path is defined
+  
 - name: Download ece installer
   get_url:
     url: "{{ ece_installer_url }}"
     dest: /home/elastic/elastic-cloud-enterprise.sh
     mode: 0755
+  when: ece_installer_path is not defined
 
 - name: Ensure ~/.docker is present
   file:


### PR DESCRIPTION
Instead of downloading the ECE installer script, this will copy it from controller machine to remote host. 
This `ece_installer_path` is optional. If missing, it will try to download it from the internet, unless the file already exists at destination (`/home/elastic/elastic-cloud-enterprise.sh`)