### PR TITLE
Ansible doesn't verify docker as running

### DIFF
--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -52,3 +52,8 @@
     name: docker
     enabled: yes
     daemon_reload: yes
+
+- name: Start the docker service
+  systemd:
+    name: docker
+    state: stopped

--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -56,4 +56,4 @@
 - name: Start the docker service
   systemd:
     name: docker
-    state: stopped
+    state: started

--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -52,8 +52,3 @@
     name: docker
     enabled: yes
     daemon_reload: yes
-
-- name: Start the docker service
-  systemd:
-    name: docker
-    state: started

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -26,6 +26,11 @@
     owner: elastic
   when: docker_config != ""
 
+- name: Ensure the docker service is started
+  systemd:
+    name: docker
+    state: started
+
 - name: Check if an installation or upgrade should be performed
   shell: docker ps -a -f name=frc-runners-runner --format {%raw%}"{{.Image}}"{%endraw%}
   register: existing_runner


### PR DESCRIPTION
We need to start docker back up prior to checking `docker ps` here: https://github.com/elastic/ansible-elastic-cloud-enterprise/blob/09bf023251380a30f114df3c478c288e0c4c6905/tasks/ece-bootstrap/main.yml#L30

This issue references the bug this PR should help resolve:
https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/109