### PR TITLE
Ubuntu 20.04 ARM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.retry
 *.local.yml
 *.local.sh

--- a/vars/os_Ubuntu_20.yml
+++ b/vars/os_Ubuntu_20.yml
@@ -11,7 +11,7 @@ docker_version_map:
       - docker-ce=5:20.10.14*
       - docker-ce-cli=5:20.10.14*
       - containerd.io
-    repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable
+    repo: deb https://download.docker.com/linux/ubuntu focal stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
       id: 0EBFCD88


### PR DESCRIPTION
Remove specific architecture from the repo specification to make it work on ARM too.