### PR TITLE
Add a new variable to allow passing additional installer arguments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,9 @@ memory:
   constructor: 4G
   adminconsole: 4G
 
+# Elastic Cloud Enterprise additional installer arguments
+extra_installer_args: ""
+
 # Elastic Cloud Enterprise - Support Diagnostics Settings
 ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.3.tar.gz"
 ece_supportdiagnostics_result_path: "/tmp/ece-support-diagnostics"

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -1,6 +1,15 @@
 ---
 - name: Execute the primary installation
-  shell: /home/elastic/elastic-cloud-enterprise.sh install --availability-zone {{ availability_zone }} --cloud-enterprise-version {{ ece_version }} --docker-registry {{ ece_docker_registry }} --ece-docker-repository {{ ece_docker_repository }} --memory-settings '{{ memory_settings }}' --runner-id {{ ece_runner_id }} --host-storage-path {{ data_dir }}/elastic
+  shell: /home/elastic/ 
+    install 
+    --availability-zone {{ availability_zone }} 
+    --cloud-enterprise-version {{ ece_version }} 
+    --docker-registry {{ ece_docker_registry }} 
+    --ece-docker-repository {{ ece_docker_repository }} 
+    --memory-settings '{{ memory_settings }}' 
+    --runner-id {{ ece_runner_id }} 
+    --host-storage-path {{ data_dir }}/elastic 
+    {{ extra_installer_args }}
   become: yes
   become_method: sudo
   become_user: elastic

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -1,6 +1,6 @@
 ---
 - name: Execute the primary installation
-  shell: /home/elastic/ 
+  shell: /home/elastic/elastic-cloud-enterprise.sh
     install 
     --availability-zone {{ availability_zone }} 
     --cloud-enterprise-version {{ ece_version }} 

--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -32,6 +32,7 @@
     --memory-settings '{{ memory_settings }}'
     --runner-id {{ ece_runner_id }}{% if capacity is defined %}
     --capacity {{ capacity }}{% endif %}
+    {{ extra_installer_args }}
   become: yes
   become_method: sudo
   become_user: elastic


### PR DESCRIPTION
This PR adds a new  `extra_installer_args` var to allow passing arbitrary additional arguments to the installer on fresh install. 