### PR TITLE
Make role idempotent and controllable by variables in addition to --skip-tags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,25 @@ force_xfc: false
 sysctl_settings_file: "/etc/sysctl.d/70-cloudenterprise.conf"
 system_limits_file: "/etc/security/limits.d/70-cloudenterprise.conf"
 
+# Do cloud-init related tasks
+ece_do_cloudinit: true
+
+# Create elastic user
+ece_do_user: true
+
+# same as --skip-tags setup_filesystem
+ece_do_setup_filesystem: true
+
+# Setup permissions
+ece_do_setup_fs_permissions: true
+
+# Set limits
+ece_do_fs_limits: true
+
+# Set bootloader settings
+ece_do_fs_bootloader: true
+ece_do_bootloader_reboot: false
+
 # Memory settings
 memory:
   runner: 1G

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,7 +15,7 @@
   ignore_errors: true
   when: ece_do_bootloader_reboot | bool
 
-- name: wait for reboot
+- name: Wait for reboot
   wait_for_connection:
     delay: 15
     sleep: 2

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,20 @@
     enabled: yes
     daemon_reload: yes
     state: restarted
+
+- name: Reboot
+  # ensure host is offline, even if it takes long to shutdown
+  shell: "sleep 5 && /sbin/shutdown -r now && systemctl stop sshd"
+  async: 1
+  poll: 0
+  # ignore errors for hosts that disconect immediatly
+  ignore_errors: true
+  when: ece_do_bootloader_reboot | bool
+
+- name: wait for reboot
+  wait_for_connection:
+    delay: 15
+    sleep: 2
+    timeout: 600
+  listen: Reboot
+  when: ece_do_bootloader_reboot | bool

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart docker
+  systemd:
+    name: docker
+    enabled: yes
+    daemon_reload: yes
+    state: restarted

--- a/tasks/base/Ubuntu-16/install_docker.yml
+++ b/tasks/base/Ubuntu-16/install_docker.yml
@@ -17,3 +17,4 @@
 
 - name: Pin docker-engine packet
   shell: echo "docker-engine hold" | sudo dpkg --set-selections
+  changed_when: false

--- a/tasks/base/Ubuntu-18/install_docker.yml
+++ b/tasks/base/Ubuntu-18/install_docker.yml
@@ -17,3 +17,4 @@
 
 - name: Pin docker-engine packet
   shell: echo "docker-engine hold" | sudo dpkg --set-selections
+  changed_when: false

--- a/tasks/base/Ubuntu-20/install_docker.yml
+++ b/tasks/base/Ubuntu-20/install_docker.yml
@@ -17,3 +17,4 @@
 
 - name: Pin docker-engine packet
   shell: echo "docker-engine hold" | sudo dpkg --set-selections
+  changed_when: false

--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -1,20 +1,17 @@
 ---
-- name: Stop the docker service
-  systemd:
-    name: docker
-    state: stopped
-
 - name: Ensures /etc/systemd/system/docker.service.d dir exists
   file:
     path: /etc/systemd/system/docker.service.d
     state: directory
   when: docker_version != '1.13'
+  notify: Restart docker
 
 - name: Create service.d docker.conf
   template:
     src: docker.conf
     dest: /etc/systemd/system/docker.service.d/docker.conf
   when: docker_version != '1.13'
+  notify: Restart docker
 
 - name: set docker storage options
   lineinfile:
@@ -24,6 +21,7 @@
     backrefs: yes
     create: yes
   when: docker_version == '1.13'
+  notify: Restart docker
 
 - name: set docker network options
   lineinfile:
@@ -32,6 +30,7 @@
     line: 'DOCKER_NETWORK_OPTIONS="--bip={{ docker_bridge_ip }}"'
     create: yes
   when: docker_version == '1.13'
+  notify: Restart docker
 
 - name: set docker storage driver
   lineinfile:
@@ -40,6 +39,7 @@
     line: 'STORAGE_DRIVER={{ docker_storage_driver }}'
     create: yes
   when: docker_version == '1.13'
+  notify: Restart docker
 
 - name: Remove var/lib/docker
   file:
@@ -47,8 +47,5 @@
     state: absent
     force: yes
 
-- name: Docker daemon is enabled and systemd has read all changes
-  systemd:
-    name: docker
-    enabled: yes
-    daemon_reload: yes
+- name: Flush handlers to trigger the (re-)start of docker if needed
+  meta: flush_handlers

--- a/tasks/base/general/make_user.yml
+++ b/tasks/base/general/make_user.yml
@@ -73,5 +73,4 @@
     dest: /etc/cloud/cloud.cfg.d/00-elastic.cfg
   vars:
     image_user: elastic
-  tags: [never, vmimage]
-  
+  when: ece_do_cloudinit | bool

--- a/tasks/base/general/make_user.yml
+++ b/tasks/base/general/make_user.yml
@@ -73,3 +73,5 @@
     dest: /etc/cloud/cloud.cfg.d/00-elastic.cfg
   vars:
     image_user: elastic
+  tags: [never, vmimage]
+  

--- a/tasks/base/general/set_limits.yml
+++ b/tasks/base/general/set_limits.yml
@@ -3,6 +3,7 @@
   file:
     path: "{{ system_limits_file }}"
     state: touch
+  changed_when: false
 
 - name: Modify pam limits
   pam_limits:

--- a/tasks/base/general/setup_mount_permissions.yml
+++ b/tasks/base/general/setup_mount_permissions.yml
@@ -14,11 +14,3 @@
     owner: elastic
     group: elastic
     mode: 0700
-
-- name: Change owner and permissions of {{ data_dir }}/docker
-  file:
-    path: "{{ data_dir }}/docker"
-    state: directory
-    owner: elastic
-    group: elastic
-    mode: 0700

--- a/tasks/base/general/sysctl_scripts.yml
+++ b/tasks/base/general/sysctl_scripts.yml
@@ -8,6 +8,7 @@
   file:
     path: "{{ sysctl_settings_file }}"
     state: touch
+  changed_when: false
 
 - name: sysctl_scripts.yml || set sysctl items
   sysctl:

--- a/tasks/base/general/update_grub_docker.yml
+++ b/tasks/base/general/update_grub_docker.yml
@@ -20,6 +20,8 @@
     dest: /etc/default/grub
     regexp: '^GRUB_CMDLINE_LINUX="'
     line: "GRUB_CMDLINE_LINUX=\"{{ (existing_grub_cmdline_linux_options | union(['cgroup_enable=memory', 'swapaccount=1', 'cgroup.memory=nokmem'])) | join(' ') }}\""
+  register: modify_grub_cmdline_linux
 
 - name: Run bootloader update
   command: "{{ bootloader_update_command }}"
+  when: modify_grub_cmdline_linux.changed

--- a/tasks/base/general/update_grub_docker.yml
+++ b/tasks/base/general/update_grub_docker.yml
@@ -21,7 +21,11 @@
     regexp: '^GRUB_CMDLINE_LINUX="'
     line: "GRUB_CMDLINE_LINUX=\"{{ (existing_grub_cmdline_linux_options | union(['cgroup_enable=memory', 'swapaccount=1', 'cgroup.memory=nokmem'])) | join(' ') }}\""
   register: modify_grub_cmdline_linux
+  notify: Reboot
 
 - name: Run bootloader update
   command: "{{ bootloader_update_command }}"
   when: modify_grub_cmdline_linux.changed
+
+- name: Run handlers
+  meta: flush_handlers

--- a/tasks/base/general/update_grub_docker.yml
+++ b/tasks/base/general/update_grub_docker.yml
@@ -1,11 +1,25 @@
 ---
+- name: Get GRUB_CMDLINE_LINUX
+  slurp:
+    src: /etc/default/grub
+  register: existing_grub_cmdline_linux
+
+- name: Set existing options list
+  set_fact:
+    existing_grub_cmdline_linux_options: >-
+      {%- set line=(existing_grub_cmdline_linux['content'] | b64decode | regex_findall('GRUB_CMDLINE_LINUX=\"(.+)\"')) -%}
+      {%- if line | length > 0 -%}
+      {{ line | first | split(' ') }}
+      {%- else -%}
+      []
+      {%- endif -%}
+
 - name: Modify GRUB_CMDLINE_LINUX
   lineinfile:
     state: present
     dest: /etc/default/grub
-    backrefs: yes
-    regexp: '^(GRUB_CMDLINE_LINUX=\"[^\"]*)(\".*)'
-    line: '\1 cgroup_enable=memory swapaccount=1 cgroup.memory=nokmem\2'
+    regexp: '^GRUB_CMDLINE_LINUX="'
+    line: "GRUB_CMDLINE_LINUX=\"{{ (existing_grub_cmdline_linux_options | union(['cgroup_enable=memory', 'swapaccount=1', 'cgroup.memory=nokmem'])) | join(' ') }}\""
 
 - name: Run bootloader update
   command: "{{ bootloader_update_command }}"

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -23,6 +23,7 @@
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}/main.yml"
 
 - include_tasks: general/dependencies.yml
+  tags: [never, vmimage]
 
 - include_tasks: general/make_user.yml
 - include_tasks: general/set_limits.yml
@@ -36,6 +37,7 @@
 - include_tasks: general/kernel_modules.yml
 
 - name: skip automatic ephemeral mount
+  tags: [never, vmimage]
   copy:
     dest: /etc/cloud/cloud.cfg.d/01-mounts.cfg
     content: |

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -23,21 +23,28 @@
   include_tasks: "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}/main.yml"
 
 - include_tasks: general/dependencies.yml
-  tags: [never, vmimage]
+  when: ece_do_cloudinit | bool
 
 - include_tasks: general/make_user.yml
+  when: ece_do_user | bool
+
 - include_tasks: general/set_limits.yml
   tags: [setup_filesystem, destructive]
-  when: ansible_lvm['vgs']['lxc'] is not defined or force_xfc == true
+  when:
+    - ansible_lvm['vgs']['lxc'] is not defined or force_xfc == true
+    - ece_do_fs_limits | bool
+
 - include_tasks: general/update_grub_docker.yml
   tags: [setup_filesystem, destructive]
+  when: ece_do_fs_bootloader | bool
+
 - include_tasks: general/configure_docker.yml
   tags: [install_docker, destructive]
 - include_tasks: general/sysctl_scripts.yml
 - include_tasks: general/kernel_modules.yml
 
 - name: skip automatic ephemeral mount
-  tags: [never, vmimage]
+  when: ece_do_cloudinit | bool
   copy:
     dest: /etc/cloud/cloud.cfg.d/01-mounts.cfg
     content: |

--- a/tasks/direct-install/main.yml
+++ b/tasks/direct-install/main.yml
@@ -1,12 +1,15 @@
 ---
 - include_tasks: setup_xfs.yml
-  tags: [never, setup_filesystem, destructive]
+  tags: [setup_filesystem, destructive]
+  when: ece_do_setup_filesystem | bool
 
 - name: Reboot the machine with all defaults
   reboot:
     msg: "Reboot for changes to take effect initiated by Ansible"
     post_reboot_delay: 10
-  tags: [never, setup_filesystem]
+  tags: [setup_filesystem]
+  when: ece_do_setup_filesystem | bool
 
 - include_tasks: ../base/general/setup_mount_permissions.yml
   tags: [setup_filesystem, setup_fs_permissions]
+  when: (ece_do_setup_filesystem | bool) or (ece_do_setup_fs_permissions | bool)

--- a/tasks/direct-install/main.yml
+++ b/tasks/direct-install/main.yml
@@ -1,12 +1,12 @@
 ---
 - include_tasks: setup_xfs.yml
-  tags: [setup_filesystem, destructive]
+  tags: [never, setup_filesystem, destructive]
 
 - name: Reboot the machine with all defaults
   reboot:
     msg: "Reboot for changes to take effect initiated by Ansible"
     post_reboot_delay: 10
-  tags: [setup_filesystem]
+  tags: [never, setup_filesystem]
 
 - include_tasks: ../base/general/setup_mount_permissions.yml
   tags: [setup_filesystem, setup_fs_permissions]

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -34,6 +34,7 @@
 - name: Check if an installation or upgrade should be performed
   shell: docker ps -a -f name=frc-runners-runner --format {%raw%}"{{.Image}}"{%endraw%}
   register: existing_runner
+  changed_when: false
 
 - name: Create memory settings
   set_fact:

--- a/tasks/ece-bootstrap/upgrade.yml
+++ b/tasks/ece-bootstrap/upgrade.yml
@@ -4,3 +4,9 @@
   become: yes
   become_method: sudo
   become_user: elastic
+  when: (existing_runner.stdout | split(':') | last) is version (ece_version, '<')
+
+- name: Notify already on desired version
+  debug:
+    msg: "The current version {{ existing_runner.stdout | split(':') | last }} is the same or newer as {{ ece_version }}"
+  when: (existing_runner.stdout | split(':') | last) is not version (ece_version, '<')


### PR DESCRIPTION
Hi

It would be nice if this role would be idempotent (only show changed on an ansible task if it realy changed somtehing on the system).
Furthermore `--skip-tags setup_filesystem` is prone to error because it is not the default behavior when running ansible.

This PR tries to fix this while remaining backwards compatible.

It changes the following:
- only show changed on an ansible task if it realy changes something on the system (makes it easy to re-run the role more than once)
- Ensure the needed kernel params in `GRUB_CMDLINE_LINUX` are only present once. Even if they are already defined in different order
- Reboot after `GRUB_CMDLINE_LINUX` is changed (controllable with `ece_do_bootloader_reboot`)
- Only execute Update if the ece_version number is higher than the running one
- Use `ece_do_*` variables in addition to the `--skip-tags` functionality (the default value of the variables represent the same behavior as it would be used with the `--skip-tags`)
- Implement `ece_do_cloudinit` to disable all cloud-init related tasks
- Use handler to restart docker service if something changes, instead of stopping it and starting it with every run
- Changing `{{ data_dir }}/docker` to `elastic` User and group makes IMHO no sense, since the docker service will change it back to `root` after a restart. So this PR removes it
