### PR TITLE
Chuckmilam fix centos yum repo urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ At least three hosts are needed for this example, a primary, a secondary, and te
   - Create a xfs partition and configure it
   - Configure docker
 
-More information about the prerequisites can be found in the following [page](https://www.elastic.co/guide/en/cloud-enterprise/2.7/ece-prereqs.html).
+More information about the prerequisites can be found in the following [page](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-prereqs.html).
 - On the primary host:
   - Make the primary installation of Elastic Cloud Enterprise
 - On the secondary host:

--- a/tasks/base/CentOS-8/install_dependencies.yml
+++ b/tasks/base/CentOS-8/install_dependencies.yml
@@ -14,7 +14,7 @@
     - replace:
         path: "{{ item.path }}"
         regexp: '#baseurl=http://mirror\.centos\.org'
-        replace: 'baseurl=http://vault.centos.org'
+        replace: 'baseurl=http://mirror.centos.org'
       with_items: "{{ repos.files }}"
 
 - name: Install base dependencies


### PR DESCRIPTION
Looks like the upstream CentOS yum repo URLs changed again, so the fix in https://github.com/elastic/ansible-elastic-cloud-enterprise/pull/158 are now a regression. 