### PR TITLE
Update setup_xfs.yml, remove deprecated "args: warn"

### DIFF
--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -59,5 +59,3 @@
 
 - name: Enable all swap devices
   command: swapon -a
-  args:
-    warn: no


### PR DESCRIPTION
For current versions of Ansible:

"The warn parameter to these modules is now deprecated and defaults to False."

Source: https://github.com/ansible/ansible/blob/v2.11.0/changelogs/CHANGELOG-v2.11.rst#deprecated-features

While I understand this role is only tested to Ansible v2.8.7, removing these two lines was all I needed to get the role to work on CentOS 8 AMIs with a current version of Ansible (core 2.15.1). 

I believe for older versions of Ansible, the missing "warn" parameter will only warn, not fail for the swapoff command here.