### PR TITLE
Bump default to latest ECE release - 3.6.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 3.5.1
+ece_version: 3.6.0
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
Relates to https://github.com/elastic/release-eng/issues/722