### PR TITLE
Adding condition "when: is_nokmem_present.rc == 1"

### DIFF
--- a/tasks/base/general/update_grub_docker.yml
+++ b/tasks/base/general/update_grub_docker.yml
@@ -6,6 +6,7 @@
     backrefs: yes
     regexp: '^(GRUB_CMDLINE_LINUX=\"[^\"]*)(\".*)'
     line: '\1 cgroup_enable=memory swapaccount=1 cgroup.memory=nokmem\2'
+  when: is_nokmem_present.rc == 1
 
 - name: Run bootloader update
   command: "{{ bootloader_update_command }}"


### PR DESCRIPTION
Adding condition "when: is_nokmem_present.rc == 1" so that it will skip this step if its already present, useful when we rerun the playbook on the same host more than once(like re deploying or removing and adding the host to another environment)