### PR TITLE
update version in ansible

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 3.6.2
+ece_version: 3.7.2
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
ECE 3.7.2 (based on ms-105) was release on 27th June .
This PR updates version used by ansible repo to latest 