### PR TITLE
fix quoting issue with memory settings

### DIFF
--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -10,7 +10,7 @@
     --cloud-enterprise-version {{ ece_version }} 
     --docker-registry {{ ece_docker_registry }} 
     --ece-docker-repository {{ ece_docker_repository }} 
-    --memory-settings '{{ memory_settings }}' 
+    --memory-settings {{ memory_settings | quote }}
     --runner-id {{ ece_runner_id }} 
     --host-storage-path {{ data_dir }}/elastic 
     {% if container_engine == "Podman" %}

--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -29,7 +29,7 @@
     --docker-registry {{ ece_docker_registry }}
     --ece-docker-repository {{ ece_docker_repository }}
     --host-storage-path {{ data_dir }}/elastic
-    --memory-settings '{{ memory_settings }}'
+    --memory-settings {{ memory_settings | quote }}
     --runner-id {{ ece_runner_id }}{% if capacity is defined %}
     --capacity {{ capacity }}{% endif %}
     {% if container_engine == "Podman" %}


### PR DESCRIPTION
The memory settings passed to the `elastic-cloud-enterprise.sh` is a dict in json format. Therefore a single quote is present in the task around the json dict. But this single quote gets transformed to an escaped single quote in the playbook execution and therefore the task fails with the following error message: ``/home/elastic/elastic-cloud-enterprise.sh: eval: line 134: unexpected EOF while looking for matching `''``

```
TASK [elastic-cloud-enterprise : Execute installation] *******************
fatal: [ece2]: FAILED! => {
    "changed": true,
    "cmd": "/home/elastic/elastic-cloud-enterprise.sh --coordinator-host ece1 --roles-token 'TOKEN' --roles 'allocator' --availability-zone zone1 --cloud-enterprise-version 3.6.2 --host-storage-path /mnt/data/elastic --memory-settings \\' {\"runner\":{\"xms\":\"1G\",\"xmx\":\"1G\"},\"proxy\":{\"xms\":\"8G\",\"xmx\":\"8G\"},\"zookeeper\":{\"xms\":\"4G\",\"xmx\":\"4G\"},\"director\":{\"xms\":\"1G\",\"xmx\":\"1G\"},\"constructor\":{\"xms\":\"4G\",\"xmx\":\"4G\"},\"admin-console\":{\"xms\":\"4G\",\"xmx\":\"4G\"}}\\' --runner-id ece2 --podman --host-docker-host /run/podman/podman.sock --force  ",
    "delta": "0:00:00.007800",
    "end": "2024-11-19 23:42:02.407117",
    "msg": "non-zero return code",
    "rc": 2,
    "start": "2024-11-19 23:42:02.399317",
    "stderr": "/home/elastic/elastic-cloud-enterprise.sh: eval: line 134: unexpected EOF while looking for matching `''",
    "stderr_lines": [
        "/home/elastic/elastic-cloud-enterprise.sh: eval: line 134: unexpected EOF while looking for matching `''"
    ],
    "stdout": "",
    "stdout_lines": []
}
```

Using `jq` to extract the _cmd_ parameter from the result json shows that the single quotes are escaped.

```
$ cat /dev/clipboard | jq -r '.cmd'
/home/elastic/elastic-cloud-enterprise.sh --coordinator-host ece1 --roles-token 'TOKEN' --roles 'allocator' --availability-zone zone1 --cloud-enterprise-version 3.6.2 --host-storage-path /mnt/data/elastic --memory-settings \' {"runner":{"xms":"1G","xmx":"1G"},"proxy":{"xms":"8G","xmx":"8G"},"zookeeper":{"xms":"4G","xmx":"4G"},"director":{"xms":"1G","xmx":"1G"},"constructor":{"xms":"4G","xmx":"4G"},"admin-console":{"xms":"4G","xmx":"4G"}}\' --runner-id ece2 --podman --host-docker-host /run/podman/podman.sock --force  
```

Ansible-base 2.10 introduces the [quote filter](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/quote_filter.html). When using this filter instead of the single quotes, the playbook executes successfully. The cmd parameter from the tasks does not show the escaped single quote any more.

```
TASK [elastic-cloud-enterprise : Execute installation] *******************
changed: [ece2] => {
    "changed": true,
    "cmd": "/home/elastic/elastic-cloud-enterprise.sh --coordinator-host ece1--roles-token 'TOKEN' --roles 'allocator' --availability-zone zone1 --cloud-enterprise-version 3.6.2 --host-storage-path /mnt/data/elastic --memory-settings ' {\"runner\":{\"xms\":\"1G\",\"xmx\":\"1G\"},\"proxy\":{\"xms\":\"8G\",\"xmx\":\"8G\"},\"zookeeper\":{\"xms\":\"4G\",\"xmx\":\"4G\"},\"director\":{\"xms\":\"1G\",\"xmx\":\"1G\"},\"constructor\":{\"xms\":\"4G\",\"xmx\":\"4G\"},\"admin-console\":{\"xms\":\"4G\",\"xmx\":\"4G\"}}' --runner-id ece2 --podman --host-docker-host /run/podman/podman.sock --force  ",
    "delta": "0:00:39.900526",
    "end": "2024-11-20 06:49:50.870312",
    "msg": "",
    "rc": 0,
    "start": "2024-11-20 06:49:10.969786",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "..",
    "stdout_lines": [".."]
}

$ cat /dev/clipboard | jq -r '.cmd'
/home/elastic/elastic-cloud-enterprise.sh --coordinator-host ece11.dkelag.local --roles-token 'TOKEN' --roles 'allocator' --availability-zone arz --cloud-enterprise-version 3.6.2 --host-storage-path /mnt/data/elastic --memory-settings ' {"runner":{"xms":"1G","xmx":"1G"},"proxy":{"xms":"8G","xmx":"8G"},"zookeeper":{"xms":"4G","xmx":"4G"},"director":{"xms":"1G","xmx":"1G"},"constructor":{"xms":"4G","xmx":"4G"},"admin-console":{"xms":"4G","xmx":"4G"}}' --runner-id ece2 --podman --host-docker-host /run/podman/podman.sock --force  
```
