### PR TITLE
ECE 4.0.1 Post-release step: Update default ECE version in ansible

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 4.0.0
+ece_version: 4.0.1
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
This PR updates the default ECE version for Ansible after ECE 4.0.1 release

Metas: https://github.com/elastic/release-eng/issues/1237