### PR TITLE
[ECE 4.0.3] Post-release: Bump ECE version to 4.0.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 4.0.2
+ece_version: 4.0.3
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
Update the default ECE version for Ansible to ECE 4.0.3.

Rel: https://github.com/elastic/release-eng/issues/1331