### PR TITLE
fix outdated pinning docker version with the official documentation

### DIFF
--- a/tasks/base/Ubuntu-22/install_docker.yml
+++ b/tasks/base/Ubuntu-22/install_docker.yml
@@ -35,4 +35,11 @@
     state: present
 
 - name: Pin docker-engine packet
-  shell: echo "docker-engine hold" | sudo dpkg --set-selections
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop:
+    - docker-engine #backward compatibility
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io


### PR DESCRIPTION
resolves https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/209

update code to resemble official doc, using builtin module instead of shell