### PR TITLE
Add Docker 25.0 support and modernize Docker installation for Ubuntu 22

### DIFF
--- a/tasks/base/Ubuntu-22/install_docker.yml
+++ b/tasks/base/Ubuntu-22/install_docker.yml
@@ -18,21 +18,43 @@
   retries: 10
   delay: 30
   until: remove_packages is success
-- name: Add docker repository key
-  apt_key:
-    url: "{{ docker_version_map[docker_version]['keys']['server'] }}"
-    id: "{{ docker_version_map[docker_version]['keys']['id'] }}"
 
-- name: Add docker repository
+- name: Install Docker repository dependencies
+  apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    state: present
+    update_cache: yes
+
+- name: Ensure /etc/apt/keyrings directory exists
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Docker GPG key and dearmor
+  command: "bash -c 'curl -fsSL {{ docker_version_map[docker_version]['keys']['server'] }} | gpg --dearmor > /etc/apt/keyrings/docker.gpg'"
+  args:
+    creates: /etc/apt/keyrings/docker.gpg
+  changed_when: false
+  become: yes
+
+- name: Add Docker repository (signed-by keyring)
   apt_repository:
-    repo: "{{ docker_version_map[docker_version]['repo'] }}"
+    repo: "deb [arch={{ (ansible_architecture == 'x86_64') | ternary('amd64', ansible_architecture) }} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_lsb.codename | default(ansible_distribution_release) }} stable"
     state: present
 
-- name: Install docker
+- name: Install Docker packages
   apt:
     name: "{{ docker_version_map[docker_version]['package'] }}"
     update_cache: yes
     state: present
 
-- name: Pin docker-engine packet
-  shell: echo "docker-engine hold" | sudo dpkg --set-selections
+- name: Hold (pin) Docker packages to prevent unintended upgrades
+  shell: |
+    apt-mark hold docker-ce docker-ce-cli containerd.io
+  become: yes
+  changed_when: false

--- a/vars/os_Ubuntu_22.yml
+++ b/vars/os_Ubuntu_22.yml
@@ -16,3 +16,12 @@ docker_version_map:
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
       id: 0EBFCD88
+  "25.0":
+    package:
+      - docker-ce=5:25.0.*
+      - docker-ce-cli=5:25.0.*
+      - containerd.io
+    repo: deb https://download.docker.com/linux/ubuntu focal stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      id: 0EBFCD88


### PR DESCRIPTION
With this change we can now use Docker version 25.0 when installing on Ubuntu 22.04 hosts. This combination should be supported as stated in [Elastic Support Matrix](https://www.elastic.co/support/matrix#elastic-cloud-enterprise). The docker installation for Ubuntu 22.04 now follows [Elastic documentation](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/configure-host-ubuntu#ece-install-docker-ubuntu) more closely. 

This PR also updates the Docker installation flow for Ubuntu 22, aligning with current Docker packaging and key management practices. 

Updated package pin method to use `apt-mark hold` to ensure relevant Docker components stay on the supported version.

Note: This was tested working by first building an image (with `base` and `vmimage` tags) and then installing ECE 3.8 on an instance built from that image, using the following variables: 
- `docker_version: "25.0"`
- `container_engine: Docker`