### PR TITLE
Set default ECE version to 4.1.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # General Elastic Cloud Enterprise relevant settings
-ece_version: 4.0.3
+ece_version: 4.1.1
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""


### PR DESCRIPTION
## Summary

Bump the default `ece_version` from `4.0.3` → **`4.1.1`** now that ECE 4.1.1 is released and promoted to the public registry.

Made with [Cursor](https://cursor.com)