### PR TITLE
Support ECE on Rocky 9 / Podman 5 and Ubuntu 22.04 / Docker 25.0 (registry auth, storage, CNI, capacity, device selection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The following variables are avaible:
 - `device_name`: The block device that is wiped and turned into the ECE data volume (the xfs partition mounted at `data_dir`)
     - **Required** (no default) unless `ece_data_device_autodetect` is enabled or the filesystem tasks are skipped via tags. The install fails fast rather than guessing which disk to format.
     - Prefer a stable identifier that survives reboots/hardware changes, e.g. `/dev/disk/by-id/nvme-...` or a `/dev/disk/by-path/...` entry, instead of a kernel name like `nvme1n1`/`sdb` (those can be reassigned by the kernel, notably on AWS Nitro/NVMe instances). Absolute paths are used as-is; a bare name is resolved under `/dev/`.
-- `ece_data_device_autodetect`: When `true` and `device_name` is unset, automatically select the single whole disk that has no partitions and no holders (e.g. a lone blank data volume). Off by default because auto-formatting the wrong disk is destructive.
+- `ece_data_device_autodetect`: When `true` and `device_name` is unset, automatically select the single whole disk that has no partitions, no holders, and no existing filesystem signature (via `blkid`) — e.g. a lone blank data volume. Disks that already carry a filesystem are skipped so autodetect will not wipe reused volumes; set `device_name` explicitly if you intend to reformat such a disk. Off by default because auto-formatting the wrong disk is destructive.
     - Default: `false`
 - `ece_primary`: Whether this host should be the primary (first) host where Elastic Cloud Enterprise is installed
     - **Required** on a single host

--- a/README.md
+++ b/README.md
@@ -87,7 +87,10 @@ The following variables are avaible:
     - This will use the local script if existing in `/home/elastic/elastic-cloud-enterprise.sh`
 - `ece_installer_path`: The location of the installation script on the controller machine. It will be copied to remote host. 
     - Default: left empty, it will download it from internet (cf. `ece_installer_url`)
-- `docker_config`: If specified as a path to a docker config, copies it to the target hosts
+- `docker_config`: Path (on the controller) to a docker `config.json` with registry credentials. When set, it is copied to the host's `ece_docker_config_dir` (owned by `elastic`) so ECE can authenticate image pulls against a private registry. It also enables the registry-auth container-config mutation described in [Private Docker registry authentication](#private-docker-registry-authentication) below. Leave empty (default) for public/unauthenticated registries.
+- `ece_docker_config_dir`: Host directory where the `docker_config` credentials are staged and which is bind-mounted into the runner/allocator containers for runtime pulls.
+    - Default: `/home/elastic/.docker`
+    - Override only if you install ECE as a user other than `elastic`. The container-side mount target is always `/home/elastic/.docker` (the `elastic` user's home inside the ECE images).
 - [Supported Docker Versions](https://www.elastic.co/guide/en/cloud-enterprise/2.7/ece-software-prereq.html#ece-linux-docker)
   - `docker_version`: Last supported version on Centos 7/8 and RHEL 7/8 is 20.0, Ubuntu 16, Ubuntu 18 and SLES 12 is 19.03.
 - `docker_bridge_ip `: The default IP of the docker bridge. Configurable to avoid overlapping with the current host subnet.
@@ -108,6 +111,20 @@ If more hosts should join an Elastic Cloud Enterpise installation when a primary
 - `primary_hostname`: The (reachable) hostname of the primary host
 - `adminconsole_root_password`: The adminconsole root password
 
+
+## Private Docker registry authentication
+
+If you pull ECE and Elastic Stack images from a **private registry that requires authentication**, set `docker_config` to a docker `config.json` containing the credentials. The role then:
+
+1. Stages that `config.json` at `ece_docker_config_dir` (default `/home/elastic/.docker`), owned by `elastic`, and installs ECE with `--docker-registry`. This is the [documented ECE host configuration](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/configure-host-rhel) and is sufficient for the initial, host-side platform-image pull.
+2. Passes an additional ECE container-config mutation to the installer (`--config-file`, generated from `templates/registry-auth.conf.j2`) that bind-mounts `ece_docker_config_dir` into the long-lived **runner** and **allocator** containers.
+
+Step 2 exists because the host `config.json` is only used for the initial pull; it is **not** visible inside the runner/allocator containers that pull Elastic Stack images (and helper images such as the vacate-data-copier) at runtime. Without the mount, those runtime pulls authenticate anonymously and fail with `PullAccessDenied` against a private registry. The mount lets them reuse the same credentials.
+
+Notes:
+
+- This behaviour is only active when `docker_config` is set. For public or unauthenticated registries (including the common air-gapped setup where images are pre-loaded onto each host, or a mirror without auth), leave `docker_config` empty and neither the credential file nor the mutation is applied.
+- The mutation uses ECE's container-config mutation mechanism, which is an internal ECE facility rather than a documented installer flag, so its exact behaviour may vary between ECE versions.
 
 ## Role Tags
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ For example in many cases you might want to install Elastic Coud Enterprise with
 
 The following variables are avaible:
 
-- `device_name`: The name of the device on which the xfs partition should be created
-    - **Required** unless filesystem tasks are skipped via tags
-    - Default: xvdb
+- `device_name`: The block device that is wiped and turned into the ECE data volume (the xfs partition mounted at `data_dir`)
+    - **Required** (no default) unless `ece_data_device_autodetect` is enabled or the filesystem tasks are skipped via tags. The install fails fast rather than guessing which disk to format.
+    - Prefer a stable identifier that survives reboots/hardware changes, e.g. `/dev/disk/by-id/nvme-...` or a `/dev/disk/by-path/...` entry, instead of a kernel name like `nvme1n1`/`sdb` (those can be reassigned by the kernel, notably on AWS Nitro/NVMe instances). Absolute paths are used as-is; a bare name is resolved under `/dev/`.
+- `ece_data_device_autodetect`: When `true` and `device_name` is unset, automatically select the single whole disk that has no partitions and no holders (e.g. a lone blank data volume). Off by default because auto-formatting the wrong disk is destructive.
+    - Default: `false`
 - `ece_primary`: Whether this host should be the primary (first) host where Elastic Cloud Enterprise is installed
     - **Required** on a single host
 - `data_dir`: Which directory to mount the xfs partition under

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,10 +28,11 @@ ece_runner_id: "{{ ansible_default_ipv4.address }}"
 # bare name is resolved under /dev/.
 device_name: ""
 # ece_data_device_autodetect: opt-in convenience for hosts that have exactly one
-# unused whole disk (no partitions, not part of any LVM/MD/mapper stack), such
-# as a single blank data volume. When device_name is unset and this is true, the
-# role selects that disk automatically. Left off by default because formatting
-# the wrong disk destroys data.
+# unused whole disk (no partitions, not part of any LVM/MD/mapper stack, and no
+# existing filesystem signature via blkid), such as a single blank data volume.
+# When device_name is unset and this is true, the role selects that disk
+# automatically. Left off by default because formatting the wrong disk destroys
+# data.
 ece_data_device_autodetect: false
 data_dir: /mnt/data
 force_xfc: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,14 @@ ece_version: 4.1.1
 ece_docker_registry: docker.elastic.co
 ece_docker_repository: cloud-enterprise
 docker_config: ""
+# Directory on the host where the elastic user's Docker registry credentials
+# (config.json) are staged from `docker_config`. ECE reads these to authenticate
+# image pulls, and they are bind-mounted into the runner/allocator containers via
+# the registry-auth container-config mutation so runtime stack-image pulls can
+# authenticate against a private registry. Override only if you install ECE as a
+# user other than `elastic`; the container-side mount target is always
+# /home/elastic/.docker (the elastic user's home inside the ECE images).
+ece_docker_config_dir: /home/elastic/.docker
 podman_config: "templates/podman.conf"
 ece_installer_url: "https://download.elastic.co/cloud/elastic-cloud-enterprise.sh"
 ece_runner_id: "{{ ansible_default_ipv4.address }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,22 @@ ece_installer_url: "https://download.elastic.co/cloud/elastic-cloud-enterprise.s
 ece_runner_id: "{{ ansible_default_ipv4.address }}"
 
 # Overall setup variables (like package versions)
-device_name: xvdb
+#
+# device_name: block device that will be wiped and turned into the ECE data
+# volume ({{ data_dir }}). This is a DESTRUCTIVE operation, so there is
+# intentionally no default: an install fails fast unless you set it explicitly
+# or opt into auto-detection below. Prefer a stable identifier that survives
+# reboots and hardware changes, e.g. /dev/disk/by-id/nvme-... or a /dev/disk/by-path
+# entry, rather than a kernel name like nvme1n1/sdb (those can be reassigned by
+# the kernel, especially on AWS Nitro/NVMe). Absolute paths are used as-is; a
+# bare name is resolved under /dev/.
+device_name: ""
+# ece_data_device_autodetect: opt-in convenience for hosts that have exactly one
+# unused whole disk (no partitions, not part of any LVM/MD/mapper stack), such
+# as a single blank data volume. When device_name is unset and this is true, the
+# role selects that disk automatically. Left off by default because formatting
+# the wrong disk destroys data.
+ece_data_device_autodetect: false
 data_dir: /mnt/data
 force_xfc: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,13 @@ fetch_diagnostics: false
 
 # General settings for docker environment
 docker_bridge_ip: "172.17.42.1/16"
+# Default open-file-descriptor (nofile) ulimit applied to every container the
+# Docker daemon starts (soft:hard). ECE's bootstrap and stack containers require
+# a high nofile limit (>= 65536). Docker <= 24 injected a large default (1048576)
+# implicitly, but Docker 25.0 removed that, so containers otherwise inherit the
+# host's 1024 soft limit and ECE's preflight check fails. Matches the host pam
+# limit set in set_limits.yml.
+docker_default_nofile: 1024000
 
 
 # User and group id, uncomment if needed to override.

--- a/tasks/base/Rocky-9/configure_cni_network.yml
+++ b/tasks/base/Rocky-9/configure_cni_network.yml
@@ -1,0 +1,24 @@
+---
+# RHEL/Rocky 9 ship Podman 4/5 which default to the netavark network backend.
+# ECE's allocator networking requires the legacy CNI backend, so switch it here.
+# This mirrors the behaviour of the Terraform podman_rhel module and the ECE
+# on-prem docs for Podman on RHEL 9.
+- name: Install CNI plugins (required for the cni network backend)
+  package:
+    name: containernetworking-plugins
+    state: present
+
+- name: Ensure /etc/containers/containers.conf exists
+  copy:
+    src: /usr/share/containers/containers.conf
+    dest: /etc/containers/containers.conf
+    remote_src: true
+    force: false
+
+- name: Use the CNI network backend for Podman
+  ini_file:
+    path: /etc/containers/containers.conf
+    section: network
+    option: network_backend
+    value: '"cni"'
+    no_extra_spaces: true

--- a/tasks/base/Rocky-9/install_podman.yml
+++ b/tasks/base/Rocky-9/install_podman.yml
@@ -3,12 +3,21 @@
   selinux:
     state: disabled
 
+# A podman_version that matches a podman_version_map key installs the latest
+# patch of that major via a dnf glob (e.g. "5" -> podman-5.* / podman-remote-5.*).
+# Any other value is treated as an explicit version so a specific release can be
+# pinned, e.g. podman_version=5.2.3 -> podman-5.2.3* / podman-remote-5.2.3*.
+- name: Resolve Podman packages
+  set_fact:
+    podman_packages: >-
+      {{ podman_version_map[podman_version]['package']
+         if podman_version in podman_version_map
+         else ['podman-' ~ podman_version ~ '*', 'podman-remote-' ~ podman_version ~ '*'] }}
+
 - name: Install Podman
   package:
-    name: "{{ podman_version_map[podman_version]['package'] }}"
+    name: "{{ podman_packages }}"
     state: present
-  loop:
-    - "{{ podman_version_map[podman_version]['package'] }}"
 
 - name: Verify that fs.may_detach_mounts is enabled
   lineinfile:

--- a/tasks/base/Rocky-9/main.yml
+++ b/tasks/base/Rocky-9/main.yml
@@ -12,7 +12,7 @@
   when: container_engine == "Podman"
 
 - ansible.builtin.include_tasks: configure_cni_network.yml
-  tags: [install_podman, destructive]
+  tags: [install_docker, destructive]
   when: container_engine == "Podman"
 
 

--- a/tasks/base/Rocky-9/main.yml
+++ b/tasks/base/Rocky-9/main.yml
@@ -8,11 +8,11 @@
 
 - ansible.builtin.include_tasks: install_dependencies.yml
 - ansible.builtin.include_tasks: install_podman.yml
-  tags: [install_docker, destructive]
+  tags: [install_podman, install_docker, destructive]
   when: container_engine == "Podman"
 
 - ansible.builtin.include_tasks: configure_cni_network.yml
-  tags: [install_docker, destructive]
+  tags: [install_podman, install_docker, destructive]
   when: container_engine == "Podman"
 
 

--- a/tasks/base/Rocky-9/main.yml
+++ b/tasks/base/Rocky-9/main.yml
@@ -10,5 +10,9 @@
 - ansible.builtin.include_tasks: install_podman.yml
   tags: [install_docker, destructive]
   when: container_engine == "Podman"
-  
+
+- ansible.builtin.include_tasks: configure_cni_network.yml
+  tags: [install_podman, destructive]
+  when: container_engine == "Podman"
+
 

--- a/tasks/base/general/configure_podman.yml
+++ b/tasks/base/general/configure_podman.yml
@@ -4,23 +4,24 @@
     name: podman
     state: stopped
 
-# Store Podman's images and runtime state on the ECE data volume ({{ data_dir }})
-# instead of the OS root disk. Podman defaults to /var/lib/containers (graphroot)
-# and stages image copies under /var/tmp, both on the small root filesystem; the
-# large ECE stack images quickly exhaust it, so pulls fail with
-# "no space left on device" and instances never boot. The Docker path already
-# relocates storage via `--data-root {{ data_dir }}/docker`; this is the Podman
-# equivalent and matches the ECE on-prem docs. The {{ data_dir }}/docker
+# Store Podman's image store (graphroot) on the ECE data volume ({{ data_dir }})
+# instead of the OS root disk. Podman defaults graphroot to /var/lib/containers on
+# the small root filesystem; the large ECE stack images quickly exhaust it, so
+# pulls fail with "no space left on device" and instances never boot. The Docker
+# path already relocates storage via `--data-root {{ data_dir }}/docker`; this is
+# the Podman equivalent and matches the ECE on-prem docs. The {{ data_dir }}/docker
 # directory is created after the data volume is mounted (setup_mount_permissions).
-- name: Store Podman images/runtime on the data volume (avoids filling the root disk)
+#
+# runroot is intentionally left at Podman's default (/run/containers/storage, a
+# tmpfs): it holds ephemeral runtime state (locks, mounts) that must be cleared on
+# reboot. Putting it on the persistent data volume can leave stale state across
+# reboots. graphroot and runroot may live on different filesystems.
+- name: Store Podman's image store on the data volume (avoids filling the root disk)
   ansible.builtin.ini_file:
     path: /etc/containers/storage.conf
     section: storage
-    option: "{{ item.option }}"
-    value: '"{{ item.value }}"'
-  loop:
-    - { option: graphroot, value: "{{ data_dir }}/docker" }
-    - { option: runroot, value: "{{ data_dir }}/docker/runroot/" }
+    option: graphroot
+    value: '"{{ data_dir }}/docker"'
 
 # Not strictly needed, allows containers to run after user logout in some situations.
 - name: Enable lingering for Elastic user

--- a/tasks/base/general/configure_podman.yml
+++ b/tasks/base/general/configure_podman.yml
@@ -4,6 +4,24 @@
     name: podman
     state: stopped
 
+# Store Podman's images and runtime state on the ECE data volume ({{ data_dir }})
+# instead of the OS root disk. Podman defaults to /var/lib/containers (graphroot)
+# and stages image copies under /var/tmp, both on the small root filesystem; the
+# large ECE stack images quickly exhaust it, so pulls fail with
+# "no space left on device" and instances never boot. The Docker path already
+# relocates storage via `--data-root {{ data_dir }}/docker`; this is the Podman
+# equivalent and matches the ECE on-prem docs. The {{ data_dir }}/docker
+# directory is created after the data volume is mounted (setup_mount_permissions).
+- name: Store Podman images/runtime on the data volume (avoids filling the root disk)
+  ansible.builtin.ini_file:
+    path: /etc/containers/storage.conf
+    section: storage
+    option: "{{ item.option }}"
+    value: '"{{ item.value }}"'
+  loop:
+    - { option: graphroot, value: "{{ data_dir }}/docker" }
+    - { option: runroot, value: "{{ data_dir }}/docker/runroot/" }
+
 # Not strictly needed, allows containers to run after user logout in some situations.
 - name: Enable lingering for Elastic user
   ansible.builtin.shell: loginctl enable-linger elastic

--- a/tasks/base/general/configure_podman.yml
+++ b/tasks/base/general/configure_podman.yml
@@ -43,6 +43,22 @@
     - SocketGroup=podman
     - DirectoryMode=0777
 
+# ECE itself drives Podman over the socket above (installed with
+# `--host-docker-host /run/podman/podman.sock`), so it does not need the `docker`
+# CLI. The ECE Podman docs still require a `/usr/bin/docker` shim, however, so
+# that operators and ECE support/diagnostic tooling can run `docker ...` on the
+# host. Point it at the same rootful socket ECE uses (via podman-remote) so those
+# commands target the containers ECE actually manages, not a rootless podman.
+- name: Install a docker -> podman shim so `docker` resolves to the ECE Podman socket
+  ansible.builtin.copy:
+    dest: /usr/bin/docker
+    mode: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      podman-remote --url unix:///run/podman/podman.sock "$@"
+
 # Not strictly needed, included out of caution for some configurations.
 # Containers spawned should retain elastic's uid
 - name: Add subuid and subgid to elastic user

--- a/tasks/base/general/setup_mount_permissions.yml
+++ b/tasks/base/general/setup_mount_permissions.yml
@@ -24,17 +24,15 @@
     mode: 0700
   when: container_engine == "Docker"
 
-# Podman's graphroot/runroot are relocated here (see configure_podman.yml). Create
-# the directory now that the data volume is mounted so rootful Podman stores stack
-# images on the large volume instead of the root disk.
+# Podman's graphroot is relocated here (see configure_podman.yml). Create the
+# directory now that the data volume is mounted so rootful Podman stores stack
+# images on the large volume instead of the root disk. runroot stays on Podman's
+# default tmpfs (/run) and is managed by Podman, so it is not created here.
 - name: Create {{ data_dir }}/docker for Podman image storage
   file:
-    path: "{{ item }}"
+    path: "{{ data_dir }}/docker"
     state: directory
     owner: root
     group: root
     mode: 0711
-  loop:
-    - "{{ data_dir }}/docker"
-    - "{{ data_dir }}/docker/runroot"
   when: container_engine == "Podman"

--- a/tasks/base/general/setup_mount_permissions.yml
+++ b/tasks/base/general/setup_mount_permissions.yml
@@ -23,3 +23,18 @@
     group: elastic
     mode: 0700
   when: container_engine == "Docker"
+
+# Podman's graphroot/runroot are relocated here (see configure_podman.yml). Create
+# the directory now that the data volume is mounted so rootful Podman stores stack
+# images on the large volume instead of the root disk.
+- name: Create {{ data_dir }}/docker for Podman image storage
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0711
+  loop:
+    - "{{ data_dir }}/docker"
+    - "{{ data_dir }}/docker/runroot"
+  when: container_engine == "Podman"

--- a/tasks/base/general/sysctl_scripts.yml
+++ b/tasks/base/general/sysctl_scripts.yml
@@ -1,29 +1,28 @@
 ---
-- name: sysctl_scripts.yml || load {{ conntrack_module }} if needed
-  modprobe:
-    name: "{{ conntrack_module }}"
-    state: present
-
-- name: Create sysctl settings file
-  file:
-    path: "{{ sysctl_settings_file }}"
-    state: touch
-
-- name: sysctl_scripts.yml || set sysctl items
+# Kernel/network tuning for ECE hosts. Mirrors the settings the legacy Terraform
+# provisioning applied so the Ansible path is equivalent.
+#
+# net.ipv4.ip_forward is the important one for container networking: the CNI/
+# bridge network can only route traffic off the container bridge (container ->
+# host -> other allocators, and back) when IP forwarding is enabled. The Docker
+# daemon turns this on implicitly when it starts, but rootful Podman + CNI does
+# NOT, so without setting it here Podman hosts silently lose cross-host container
+# routing and allocator-to-allocator operations (vacate/move) stall.
+#
+# The remaining values are standard ECE host tuning: vm.max_map_count is required
+# by Elasticsearch, net.ipv4.tcp_retries2 bounds the TCP retransmission timeout
+# (per the Elasticsearch system config guidance), and vm.swappiness keeps the
+# host from swapping too early.
+- name: Apply ECE sysctl settings
   sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
-    reload: yes
-    state: present
-    sysctl_set: yes 
     sysctl_file: "{{ sysctl_settings_file }}"
-  with_items:
-  -  { name: 'net.ipv4.tcp_max_syn_backlog', value: '65536' }
-  -  { name: 'net.core.somaxconn', value: '32768' }
-  -  { name: 'net.core.netdev_max_backlog', value: '32768' }
-  -  { name: 'vm.max_map_count', value: '262144' }
-  -  { name: 'vm.swappiness', value: '1' }
-  -  { name: 'net.ipv4.tcp_keepalive_time', value: '1800' }
-  -  { name: 'net.netfilter.nf_conntrack_tcp_timeout_established', value: '7200' }
-  -  { name: 'net.netfilter.nf_conntrack_max', value: '262140' }
-  -  { name: 'net.ipv4.ip_forward', value: '1'}
+    sysctl_set: yes
+    state: present
+    reload: yes
+  loop:
+    - { name: net.ipv4.ip_forward, value: "1" }
+    - { name: vm.max_map_count, value: "262144" }
+    - { name: net.ipv4.tcp_retries2, value: "5" }
+    - { name: vm.swappiness, value: "1" }

--- a/tasks/base/general/sysctl_scripts.yml
+++ b/tasks/base/general/sysctl_scripts.yml
@@ -1,28 +1,29 @@
 ---
-# Kernel/network tuning for ECE hosts. Mirrors the settings the legacy Terraform
-# provisioning applied so the Ansible path is equivalent.
-#
-# net.ipv4.ip_forward is the important one for container networking: the CNI/
-# bridge network can only route traffic off the container bridge (container ->
-# host -> other allocators, and back) when IP forwarding is enabled. The Docker
-# daemon turns this on implicitly when it starts, but rootful Podman + CNI does
-# NOT, so without setting it here Podman hosts silently lose cross-host container
-# routing and allocator-to-allocator operations (vacate/move) stall.
-#
-# The remaining values are standard ECE host tuning: vm.max_map_count is required
-# by Elasticsearch, net.ipv4.tcp_retries2 bounds the TCP retransmission timeout
-# (per the Elasticsearch system config guidance), and vm.swappiness keeps the
-# host from swapping too early.
-- name: Apply ECE sysctl settings
+- name: sysctl_scripts.yml || load {{ conntrack_module }} if needed
+  modprobe:
+    name: "{{ conntrack_module }}"
+    state: present
+
+- name: Create sysctl settings file
+  file:
+    path: "{{ sysctl_settings_file }}"
+    state: touch
+
+- name: sysctl_scripts.yml || set sysctl items
   sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
-    sysctl_file: "{{ sysctl_settings_file }}"
-    sysctl_set: yes
-    state: present
     reload: yes
-  loop:
-    - { name: net.ipv4.ip_forward, value: "1" }
-    - { name: vm.max_map_count, value: "262144" }
-    - { name: net.ipv4.tcp_retries2, value: "5" }
-    - { name: vm.swappiness, value: "1" }
+    state: present
+    sysctl_set: yes 
+    sysctl_file: "{{ sysctl_settings_file }}"
+  with_items:
+  -  { name: 'net.ipv4.tcp_max_syn_backlog', value: '65536' }
+  -  { name: 'net.core.somaxconn', value: '32768' }
+  -  { name: 'net.core.netdev_max_backlog', value: '32768' }
+  -  { name: 'vm.max_map_count', value: '262144' }
+  -  { name: 'vm.swappiness', value: '1' }
+  -  { name: 'net.ipv4.tcp_keepalive_time', value: '1800' }
+  -  { name: 'net.netfilter.nf_conntrack_tcp_timeout_established', value: '7200' }
+  -  { name: 'net.netfilter.nf_conntrack_max', value: '262140' }
+  -  { name: 'net.ipv4.ip_forward', value: '1'}

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -50,7 +50,7 @@
   tags: [install_docker, destructive]
   when: container_engine == "Docker"
 - include_tasks: general/configure_podman.yml
-  tags: [install_podman, destructive]
+  tags: [install_podman, install_docker, destructive]
   when: container_engine == "Podman"
 - include_tasks: general/sysctl_scripts.yml
 - include_tasks: general/kernel_modules.yml

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -31,8 +31,8 @@
 
 - name: Assert Podman version is supported
   assert:
-    that: "podman_version in podman_version_map.keys()"
-    msg: "Podman version must be one of {{ podman_version_map.keys() }}"
+    that: "podman_version in podman_version_map.keys() or podman_version is match('^[0-9][0-9.]*$')"
+    msg: "Podman version must be one of {{ podman_version_map.keys() }} (latest patch of that major) or an explicit version such as 5.2.3"
   when: container_engine == "Podman"
 
 - name: execute os specific tasks

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -10,14 +10,17 @@
     msg: "ERROR: OS {{ ansible_distribution }} {{ ansible_distribution_major_version}} is not supported!"
   when: unsupported_version is defined and unsupported_version
 
+# default(..., true) so an empty string (e.g. docker_version= passed through from
+# an unset CI variable) also falls back to the map default, not just an undefined
+# value.
 - name: Set Docker version
   set_fact:
-    docker_version: "{{ docker_version | default(docker_version_map.keys()|list|last) }}"
+    docker_version: "{{ docker_version | default(docker_version_map.keys()|list|last, true) }}"
   when: container_engine == "Docker"
 
 - name: Set Podman version
   set_fact:
-    podman_version: "{{ podman_version | default(podman_version_map.keys()|list|last) }}"
+    podman_version: "{{ podman_version | default(podman_version_map.keys()|list|last, true) }}"
   when: container_engine == "Podman"
 
 - name: Assert Docker version is supported

--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -1,4 +1,38 @@
 ---
+# Resolve which block device becomes the ECE data volume. Kernel names such as
+# nvme1n1 are not stable (on AWS Nitro the data EBS volume can enumerate as
+# nvme1n1 on one host and nvme2n1 on another, and nvme1n1 may even be the
+# partitioned root disk), so we never guess: use the operator-provided
+# device_name, or an explicitly opted-in single unused disk, and fail otherwise.
+- name: Auto-detect the ECE data device (opt-in, single unused disk)
+  set_fact:
+    device_name: >-
+      {{ (ansible_devices | dict2items
+          | rejectattr('key', 'match', '^(loop|sr|dm-|md|fd|ram|zram)')
+          | selectattr('value.partitions', 'equalto', {})
+          | selectattr('value.holders', 'equalto', [])
+          | map(attribute='key') | list | first) | default('', true) }}
+  when:
+    - device_name | default('', true) | length == 0
+    - ece_data_device_autodetect | bool
+
+- name: Assert the ECE data device is defined
+  assert:
+    that: device_name | default('', true) | length > 0
+    fail_msg: >-
+      No ECE data device configured. Set 'device_name' to the block device that
+      should back {{ data_dir }} (ideally a stable path such as
+      /dev/disk/by-id/nvme-...), or set ece_data_device_autodetect=true when the
+      host has exactly one unused whole disk. Refusing to guess which disk to
+      format.
+    success_msg: "Using '{{ device_name }}' for the ECE data volume ({{ data_dir }})."
+
+# Absolute paths (stable /dev/disk/by-id, /dev/disk/by-path, ...) are used
+# verbatim; a bare kernel name is resolved under /dev/.
+- name: Resolve the ECE data device path
+  set_fact:
+    ece_data_device: "{{ device_name if device_name.startswith('/') else '/dev/' ~ device_name }}"
+
 - name: Make sure {{ data_dir }} exists
   file:
     path: "{{ data_dir }}"
@@ -7,7 +41,7 @@
 - name: Create the volume
   lvg:
     vg: lxc
-    pvs: /dev/{{ device_name }}
+    pvs: "{{ ece_data_device }}"
     force: true
 
 - name: Define size of swap

--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -4,14 +4,39 @@
 # nvme1n1 on one host and nvme2n1 on another, and nvme1n1 may even be the
 # partitioned root disk), so we never guess: use the operator-provided
 # device_name, or an explicitly opted-in single unused disk, and fail otherwise.
-- name: Auto-detect the ECE data device (opt-in, single unused disk)
+- name: Enumerate candidate unused whole disks
   set_fact:
-    device_name: >-
-      {{ (ansible_devices | dict2items
-          | rejectattr('key', 'match', '^(loop|sr|dm-|md|fd|ram|zram)')
-          | selectattr('value.partitions', 'equalto', {})
-          | selectattr('value.holders', 'equalto', [])
-          | map(attribute='key') | list | first) | default('', true) }}
+    ece_data_device_candidates: >-
+      {{ ansible_devices | dict2items
+         | rejectattr('key', 'match', '^(loop|sr|dm-|md|fd|ram|zram)')
+         | selectattr('value.partitions', 'equalto', {})
+         | selectattr('value.holders', 'equalto', [])
+         | map(attribute='key') | list }}
+  when:
+    - device_name | default('', true) | length == 0
+    - ece_data_device_autodetect | bool
+
+# Auto-detect is only safe when there is exactly one unused disk. Refuse to pick
+# from several, otherwise we would silently format whichever sorts first -- the
+# same "guess which disk to format" failure this resolution logic exists to
+# prevent. The operator must set device_name explicitly to disambiguate.
+- name: Assert auto-detection found exactly one unused disk
+  assert:
+    that: ece_data_device_candidates | length == 1
+    fail_msg: >-
+      ece_data_device_autodetect found {{ ece_data_device_candidates | length }}
+      candidate unused disks ({{ ece_data_device_candidates | join(', ') | default('none', true) }}).
+      Auto-detection only supports exactly one unused whole disk. Set 'device_name'
+      explicitly (ideally a stable path such as /dev/disk/by-id/nvme-...) to choose
+      which disk backs {{ data_dir }}.
+    success_msg: "Auto-detected the ECE data device: {{ ece_data_device_candidates | first }}."
+  when:
+    - device_name | default('', true) | length == 0
+    - ece_data_device_autodetect | bool
+
+- name: Use the single auto-detected unused disk
+  set_fact:
+    device_name: "{{ ece_data_device_candidates | first }}"
   when:
     - device_name | default('', true) | length == 0
     - ece_data_device_autodetect | bool

--- a/tasks/direct-install/setup_xfs.yml
+++ b/tasks/direct-install/setup_xfs.yml
@@ -16,6 +16,34 @@
     - device_name | default('', true) | length == 0
     - ece_data_device_autodetect | bool
 
+# Whole-disk filesystems (no partition table) still look "unused" in
+# ansible_devices. Reject anything blkid already recognizes so autodetect does
+# not wipe an existing volume; operators with intentional reuse must set
+# device_name explicitly.
+- name: Probe auto-detect candidates for existing filesystem signatures
+  ansible.builtin.command: blkid /dev/{{ item }}
+  register: ece_data_device_blkid
+  changed_when: false
+  failed_when: false
+  loop: "{{ ece_data_device_candidates }}"
+  when:
+    - device_name | default('', true) | length == 0
+    - ece_data_device_autodetect | bool
+    - ece_data_device_candidates | length > 0
+
+- name: Drop candidates that already have a filesystem signature
+  set_fact:
+    ece_data_device_candidates: >-
+      {{ ece_data_device_blkid.results
+         | selectattr('rc', 'ne', 0)
+         | map(attribute='item')
+         | list }}
+  when:
+    - device_name | default('', true) | length == 0
+    - ece_data_device_autodetect | bool
+    - ece_data_device_blkid is defined
+    - ece_data_device_blkid.results is defined
+
 # Auto-detect is only safe when there is exactly one unused disk. Refuse to pick
 # from several, otherwise we would silently format whichever sorts first -- the
 # same "guess which disk to format" failure this resolution logic exists to
@@ -25,10 +53,11 @@
     that: ece_data_device_candidates | length == 1
     fail_msg: >-
       ece_data_device_autodetect found {{ ece_data_device_candidates | length }}
-      candidate unused disks ({{ ece_data_device_candidates | join(', ') | default('none', true) }}).
-      Auto-detection only supports exactly one unused whole disk. Set 'device_name'
-      explicitly (ideally a stable path such as /dev/disk/by-id/nvme-...) to choose
-      which disk backs {{ data_dir }}.
+      candidate unused blank disks ({{ ece_data_device_candidates | join(', ') | default('none', true) }}).
+      Auto-detection only supports exactly one unused whole disk with no
+      existing filesystem signature. Set 'device_name' explicitly (ideally a
+      stable path such as /dev/disk/by-id/nvme-...) to choose which disk backs
+      {{ data_dir }}.
     success_msg: "Auto-detected the ECE data device: {{ ece_data_device_candidates | first }}."
   when:
     - device_name | default('', true) | length == 0

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -21,6 +21,8 @@
     path: "{{ ece_docker_config_dir }}"
     state: directory
     owner: elastic
+    group: elastic
+    mode: "0700"
   when: docker_config != ""
 
 - name: Ensure ~/.config/containers/containers.conf is present
@@ -35,6 +37,8 @@
     src: "{{ docker_config }}"
     dest: "{{ ece_docker_config_dir }}/config.json"
     owner: elastic
+    group: elastic
+    mode: "0600"
   when: docker_config != ""
 
 # The installer only exposes the host docker config for the initial host-side

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -37,6 +37,19 @@
     owner: elastic
   when: docker_config != ""
 
+# The installer only exposes the host docker config for the initial host-side
+# image pull; the long-lived runner/allocator containers that pull images at
+# runtime never see it, so private-registry runtime pulls fail with
+# PullAccessDenied. Stage a container-config mutation that bind-mounts the
+# elastic docker config into those containers and pass it to the installer via
+# --config-file (see install_stack.yml). Only needed when credentials are set.
+- name: Stage registry-auth container-config mutation
+  template:
+    src: registry-auth.conf.j2
+    dest: /home/elastic/registry-auth.conf
+    owner: elastic
+  when: docker_config != ""
+
 - name: Copy local Podman config
   copy:
     src: "{{ podman_config }}"

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -13,12 +13,15 @@
     mode: 0755
   when: ece_installer_path is not defined
 
+# ~/.docker/config.json carries the registry credentials needed to pull ECE
+# images. Podman reads it via its auth fallback chain, so provision it for both
+# Docker and Podman whenever a docker_config is supplied.
 - name: Ensure ~/.docker is present
   file:
     path: /home/elastic/.docker/
     state: directory
     owner: elastic
-  when: container_engine == "Docker"
+  when: docker_config != ""
 
 - name: Ensure ~/.config/containers/containers.conf is present
   file:
@@ -32,7 +35,7 @@
     src: "{{ docker_config }}"
     dest: /home/elastic/.docker/config.json
     owner: elastic
-  when: docker_config != "" and container_engine == "Docker"
+  when: docker_config != ""
 
 - name: Copy local Podman config
   copy:

--- a/tasks/ece-bootstrap/main.yml
+++ b/tasks/ece-bootstrap/main.yml
@@ -18,7 +18,7 @@
 # Docker and Podman whenever a docker_config is supplied.
 - name: Ensure ~/.docker is present
   file:
-    path: /home/elastic/.docker/
+    path: "{{ ece_docker_config_dir }}"
     state: directory
     owner: elastic
   when: docker_config != ""
@@ -33,7 +33,7 @@
 - name: Copy local Docker config
   copy:
     src: "{{ docker_config }}"
-    dest: /home/elastic/.docker/config.json
+    dest: "{{ ece_docker_config_dir }}/config.json"
     owner: elastic
   when: docker_config != ""
 

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -39,7 +39,7 @@
   block:
     - name: Monitor installer progress
       ansible.builtin.shell:
-        cmd: tail -n 5 /mnt/data/elastic/logs/bootstrap-logs/bootstrap.log
+        cmd: tail -n 5 {{ data_dir }}/elastic/logs/bootstrap-logs/bootstrap.log
       until: "'[no.found.util.LogApplicationExit$] Application is exiting {}' in ece_installer_result_text.stdout"
       register: ece_installer_result_text
       retries: 192
@@ -58,6 +58,8 @@
       ansible.builtin.debug:
         var: ece_primary_install_status
 
+    # List log paths and dump credential-filtered excerpts only — raw tails can
+    # contain installer tokens/passwords on a failed bootstrap.
     - name: Collect any on-disk bootstrap logs
       ansible.builtin.shell: |
         set +e
@@ -65,8 +67,14 @@
         ls -la {{ data_dir }}/elastic/logs/bootstrap-logs/ 2>&1
         echo "== *.log under {{ data_dir }}/elastic =="
         find {{ data_dir }}/elastic -maxdepth 4 -name '*.log' 2>/dev/null
-        echo "== tail bootstrap logs =="
-        tail -n 80 {{ data_dir }}/elastic/logs/bootstrap-logs/*.log 2>&1
+        echo "== filtered bootstrap log excerpts =="
+        for f in {{ data_dir }}/elastic/logs/bootstrap-logs/*.log; do
+          [ -f "$f" ] || continue
+          echo "-- $f --"
+          grep -iE 'exception|error|caused by|invalid|failed|no such file|denied' "$f" \
+            | grep -ivE 'password|secret|token|authorization|bearer|api[_-]?key' \
+            | tail -n 80
+        done
       register: ece_bootstrap_debug
       changed_when: false
       ignore_errors: true

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -81,21 +81,32 @@
           ECE primary installation did not complete. See the installer async
           result and bootstrap logs above for the underlying error.
 
-# Surface any installer errors from the bootstrap log so a failed/aborted
-# install produces an actionable message instead of an opaque "secrets file
-# missing" further down. Filters to error-ish lines and explicitly drops any
-# line that could carry a credential (password/secret/token).
-- name: Surface installer errors from the bootstrap log
-  ansible.builtin.shell: >-
-    grep -iE 'exception|error|caused by|invalid|failed|no such file|denied|config' {{ data_dir }}/elastic/logs/bootstrap-logs/bootstrap.log
-    | grep -ivE 'password|secret|token' | tail -n 60
-  register: bootstrap_errors
-  changed_when: false
-  failed_when: false
+# If the monitor saw the exit marker but bootstrap-secrets.json was never
+# written, dump credential-filtered bootstrap log context instead of failing
+# later with an opaque "secrets file missing".
+- name: Ensure bootstrap secrets were written
+  ansible.builtin.stat:
+    path: "{{ data_dir }}/elastic/bootstrap-state/bootstrap-secrets.json"
+  register: bootstrap_secrets_stat
 
-- name: Show installer errors from the bootstrap log
-  ansible.builtin.debug:
-    var: bootstrap_errors.stdout_lines
+- name: Explain missing secrets using bootstrap log
+  when: not bootstrap_secrets_stat.stat.exists
+  block:
+    - name: Collect installer errors from the bootstrap log
+      ansible.builtin.shell: >-
+        grep -iE 'exception|error|caused by|invalid|failed|no such file|denied'
+        {{ data_dir }}/elastic/logs/bootstrap-logs/bootstrap.log
+        | grep -ivE 'password|secret|token|authorization|bearer|api[_-]?key'
+        | tail -n 60
+      register: bootstrap_errors
+      changed_when: false
+      failed_when: false
+
+    - name: Fail without bootstrap secrets
+      ansible.builtin.fail:
+        msg: >-
+          Install finished without bootstrap-secrets.json.
+          Matching log lines: {{ bootstrap_errors.stdout_lines }}
 
 - name: Remember the bootstrap secrets
   command: cat {{ data_dir }}/elastic/bootstrap-state/bootstrap-secrets.json

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -81,6 +81,22 @@
           ECE primary installation did not complete. See the installer async
           result and bootstrap logs above for the underlying error.
 
+# Surface any installer errors from the bootstrap log so a failed/aborted
+# install produces an actionable message instead of an opaque "secrets file
+# missing" further down. Filters to error-ish lines and explicitly drops any
+# line that could carry a credential (password/secret/token).
+- name: Surface installer errors from the bootstrap log
+  ansible.builtin.shell: >-
+    grep -iE 'exception|error|caused by|invalid|failed|no such file|denied|config' {{ data_dir }}/elastic/logs/bootstrap-logs/bootstrap.log
+    | grep -ivE 'password|secret|token' | tail -n 60
+  register: bootstrap_errors
+  changed_when: false
+  failed_when: false
+
+- name: Show installer errors from the bootstrap log
+  ansible.builtin.debug:
+    var: bootstrap_errors.stdout_lines
+
 - name: Remember the bootstrap secrets
   command: cat {{ data_dir }}/elastic/bootstrap-state/bootstrap-secrets.json
   register: secrets

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -19,6 +19,9 @@
     --host-docker-host /run/podman/podman.sock
     --force
     {% endif %}
+    {% if docker_config != "" %}
+    --config-file /home/elastic/registry-auth.conf
+    {% endif %}
     {{ extra_installer_args }}
   become: yes
   become_method: sudo

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -24,14 +24,58 @@
   become_user: elastic
   async: 960
   poll: 0
+  register: ece_primary_install
 
-- name: Monitor installer progress
-  ansible.builtin.shell: 
-    cmd: tail -n 5 /mnt/data/elastic/logs/bootstrap-logs/bootstrap.log
-  until: "'[no.found.util.LogApplicationExit$] Application is exiting {}' in ece_installer_result_text.stdout"
-  register: ece_installer_result_text
-  retries: 192
-  delay: 5
+# The installer runs asynchronously and writes to bootstrap.log; we poll that
+# file for the completion marker. If it never completes (or never even creates
+# the log, e.g. the installer aborts during its preflight checks), surface the
+# installer's own output and any on-disk logs before failing, otherwise the only
+# symptom is an opaque "tail: cannot open .../bootstrap.log" after 192 retries.
+- name: Monitor and complete the ECE installation
+  block:
+    - name: Monitor installer progress
+      ansible.builtin.shell:
+        cmd: tail -n 5 /mnt/data/elastic/logs/bootstrap-logs/bootstrap.log
+      until: "'[no.found.util.LogApplicationExit$] Application is exiting {}' in ece_installer_result_text.stdout"
+      register: ece_installer_result_text
+      retries: 192
+      delay: 5
+  rescue:
+    - name: Collect the installer async result
+      ansible.builtin.async_status:
+        jid: "{{ ece_primary_install.ansible_job_id }}"
+      register: ece_primary_install_status
+      become: yes
+      become_method: sudo
+      become_user: elastic
+      ignore_errors: true
+
+    - name: Show the installer async result (stdout/stderr/rc)
+      ansible.builtin.debug:
+        var: ece_primary_install_status
+
+    - name: Collect any on-disk bootstrap logs
+      ansible.builtin.shell: |
+        set +e
+        echo "== ls bootstrap-logs =="
+        ls -la {{ data_dir }}/elastic/logs/bootstrap-logs/ 2>&1
+        echo "== *.log under {{ data_dir }}/elastic =="
+        find {{ data_dir }}/elastic -maxdepth 4 -name '*.log' 2>/dev/null
+        echo "== tail bootstrap logs =="
+        tail -n 80 {{ data_dir }}/elastic/logs/bootstrap-logs/*.log 2>&1
+      register: ece_bootstrap_debug
+      changed_when: false
+      ignore_errors: true
+
+    - name: Show on-disk bootstrap logs
+      ansible.builtin.debug:
+        var: ece_bootstrap_debug.stdout_lines
+
+    - name: Fail after collecting installer diagnostics
+      ansible.builtin.fail:
+        msg: >-
+          ECE primary installation did not complete. See the installer async
+          result and bootstrap logs above for the underlying error.
 
 - name: Remember the bootstrap secrets
   command: cat {{ data_dir }}/elastic/bootstrap-state/bootstrap-secrets.json

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -12,7 +12,8 @@
     --ece-docker-repository {{ ece_docker_repository }} 
     --memory-settings '{{ memory_settings }}' 
     --runner-id {{ ece_runner_id }} 
-    --host-storage-path {{ data_dir }}/elastic 
+    --host-storage-path {{ data_dir }}/elastic{% if capacity is defined %}
+    --capacity {{ capacity }}{% endif %}
     {% if container_engine == "Podman" %}
     --podman
     --host-docker-host /run/podman/podman.sock

--- a/tasks/ece-bootstrap/primary/install_stack.yml
+++ b/tasks/ece-bootstrap/primary/install_stack.yml
@@ -12,8 +12,7 @@
     --ece-docker-repository {{ ece_docker_repository }} 
     --memory-settings '{{ memory_settings }}' 
     --runner-id {{ ece_runner_id }} 
-    --host-storage-path {{ data_dir }}/elastic{% if capacity is defined %}
-    --capacity {{ capacity }}{% endif %}
+    --host-storage-path {{ data_dir }}/elastic 
     {% if container_engine == "Podman" %}
     --podman
     --host-docker-host /run/podman/podman.sock

--- a/tasks/ece-bootstrap/secondary/install_stack.yml
+++ b/tasks/ece-bootstrap/secondary/install_stack.yml
@@ -37,6 +37,9 @@
     --host-docker-host /run/podman/podman.sock
     --force
     {% endif %}
+    {% if docker_config != "" %}
+    --config-file /home/elastic/registry-auth.conf
+    {% endif %}
     {{ extra_installer_args }}
   become: yes
   become_method: sudo

--- a/templates/docker.conf
+++ b/templates/docker.conf
@@ -4,7 +4,7 @@ After={{ docker_unit_after }}
 
 [Service]
 EnvironmentFile=
-Environment="DOCKER_OPTS=-H unix:///var/run/docker.sock --data-root {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false"
+Environment="DOCKER_OPTS=-H unix:///var/run/docker.sock --data-root {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false --default-ulimit nofile={{ docker_default_nofile }}:{{ docker_default_nofile }}"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure

--- a/templates/registry-auth.conf.j2
+++ b/templates/registry-auth.conf.j2
@@ -11,9 +11,20 @@
 # directory into the runner and allocator containers so their runtime pulls can
 # authenticate. It is passed to the installer via --config-file and is only
 # staged/used when a docker_config is supplied.
+#
+# NOTE: each create-payload must carry a recognised payload section in addition
+# to HostConfig (e.g. Env). ECE's SharedSettings parser returns "No result when
+# parsing failed" for a create-payload that contains only HostConfig, so we add a
+# benign marker env var to give the parser a result. This mirrors the shape of
+# the built-in container mutations (which always pair HostConfig with Env/Ports).
 found.bootstrap.shared.containers.mutations."REGISTRY_AUTH" {
   runners.runner {
     create-payload {
+      Env {
+        add = [
+          "ECE_REGISTRY_AUTH_MUTATION=applied"
+        ]
+      }
       HostConfig {
         Binds {
           add = {
@@ -25,6 +36,11 @@ found.bootstrap.shared.containers.mutations."REGISTRY_AUTH" {
   }
   allocators.allocator {
     create-payload {
+      Env {
+        add = [
+          "ECE_REGISTRY_AUTH_MUTATION=applied"
+        ]
+      }
       HostConfig {
         Binds {
           add = {

--- a/templates/registry-auth.conf.j2
+++ b/templates/registry-auth.conf.j2
@@ -1,0 +1,37 @@
+# Registry-auth container-config mutation.
+#
+# ECE reads private-registry credentials from a docker config.json, but the
+# installer only mounts that file for the initial host-side image pull -- it is
+# NOT visible inside the long-lived runner/allocator containers that pull images
+# at runtime (e.g. stack images, or the vacate-data-copier during a move). Those
+# runtime pulls therefore fail with PullAccessDenied against private registries
+# unless the credentials are mounted into the containers.
+#
+# This container-config mutation bind-mounts the elastic user's docker config
+# directory into the runner and allocator containers so their runtime pulls can
+# authenticate. It is passed to the installer via --config-file and is only
+# staged/used when a docker_config is supplied.
+found.bootstrap.shared.containers.mutations."REGISTRY_AUTH" {
+  runners.runner {
+    create-payload {
+      HostConfig {
+        Binds {
+          add = {
+            "/home/elastic/.docker" = "/home/elastic/.docker"
+          }
+        }
+      }
+    }
+  }
+  allocators.allocator {
+    create-payload {
+      HostConfig {
+        Binds {
+          add = {
+            "/home/elastic/.docker" = "/home/elastic/.docker"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/registry-auth.conf.j2
+++ b/templates/registry-auth.conf.j2
@@ -7,10 +7,16 @@
 # runtime pulls therefore fail with PullAccessDenied against private registries
 # unless the credentials are mounted into the containers.
 #
-# This container-config mutation bind-mounts the elastic user's docker config
-# directory into the runner and allocator containers so their runtime pulls can
-# authenticate. It is passed to the installer via --config-file and is only
-# staged/used when a docker_config is supplied.
+# This container-config mutation bind-mounts the host's docker config directory
+# ({{ ece_docker_config_dir }}) into the runner and allocator containers so their
+# runtime pulls can authenticate. It is passed to the installer via --config-file
+# and is only staged/used when a docker_config is supplied.
+#
+# The bind is "<host path>" = "<container path>". The host path is
+# ece_docker_config_dir (where the role staged config.json). The container path is
+# always /home/elastic/.docker: inside the ECE images the process runs as the
+# elastic user with HOME=/home/elastic, so it reads $HOME/.docker/config.json
+# regardless of which host user installed ECE.
 #
 # The mutation key MUST be "DEV": ECE's SharedSettings.fromConfig treats every
 # mutation key other than the special "DEV" bucket as a platform version and runs
@@ -24,7 +30,7 @@ found.bootstrap.shared.containers.mutations."DEV" {
       HostConfig {
         Binds {
           add = {
-            "/home/elastic/.docker" = "/home/elastic/.docker"
+            "{{ ece_docker_config_dir }}" = "/home/elastic/.docker"
           }
         }
       }
@@ -35,7 +41,7 @@ found.bootstrap.shared.containers.mutations."DEV" {
       HostConfig {
         Binds {
           add = {
-            "/home/elastic/.docker" = "/home/elastic/.docker"
+            "{{ ece_docker_config_dir }}" = "/home/elastic/.docker"
           }
         }
       }

--- a/templates/registry-auth.conf.j2
+++ b/templates/registry-auth.conf.j2
@@ -12,19 +12,15 @@
 # authenticate. It is passed to the installer via --config-file and is only
 # staged/used when a docker_config is supplied.
 #
-# NOTE: each create-payload must carry a recognised payload section in addition
-# to HostConfig (e.g. Env). ECE's SharedSettings parser returns "No result when
-# parsing failed" for a create-payload that contains only HostConfig, so we add a
-# benign marker env var to give the parser a result. This mirrors the shape of
-# the built-in container mutations (which always pair HostConfig with Env/Ports).
-found.bootstrap.shared.containers.mutations."REGISTRY_AUTH" {
+# The mutation key MUST be "DEV": ECE's SharedSettings.fromConfig treats every
+# mutation key other than the special "DEV" bucket as a platform version and runs
+# it through PlatformVersion.fromString(...), which fails for an arbitrary name
+# with "No result when parsing failed" and aborts the install. The "DEV" bucket
+# is the version-agnostic mutation that is always applied, which is exactly what
+# we want for a persistent credential bind-mount.
+found.bootstrap.shared.containers.mutations."DEV" {
   runners.runner {
     create-payload {
-      Env {
-        add = [
-          "ECE_REGISTRY_AUTH_MUTATION=applied"
-        ]
-      }
       HostConfig {
         Binds {
           add = {
@@ -36,11 +32,6 @@ found.bootstrap.shared.containers.mutations."REGISTRY_AUTH" {
   }
   allocators.allocator {
     create-payload {
-      Env {
-        add = [
-          "ECE_REGISTRY_AUTH_MUTATION=applied"
-        ]
-      }
       HostConfig {
         Binds {
           add = {

--- a/vars/os_Rocky_9.yml
+++ b/vars/os_Rocky_9.yml
@@ -3,10 +3,20 @@ bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 container_engine: Podman
 
-# Podman version mapping
+# Podman version mapping. Package specs are dnf globs so the latest available
+# patch release for the chosen major is installed (matching the ECE docs
+# `dnf install podman-<major>.* podman-remote-<major>.*`). This also avoids the
+# podman 5.2.2-11/5.2.2-13 memory-leak releases, since current Rocky 9 repos ship
+# a later 5.x. Default (last key) is Podman 5, the recommended runtime for new
+# Rocky 9 installs.
 podman_version_map:
-  "4.9.4":
+  "4":
     name: "podman"
     package:
-      - podman-4.9.4
-      - podman-remote-4.9.4
+      - podman-4.*
+      - podman-remote-4.*
+  "5":
+    name: "podman"
+    package:
+      - podman-5.*
+      - podman-remote-5.*

--- a/vars/os_Ubuntu_22.yml
+++ b/vars/os_Ubuntu_22.yml
@@ -5,14 +5,26 @@ bootloader_update_command: update-grub
 conntrack_module: xt_conntrack
 container_engine: Docker
 
-# Docker version mapping
+# Docker version mapping. Ubuntu 22.04 is "jammy" (the repo previously pointed at
+# "focal"/20.04). Package specs pin the major via apt globs so the latest patch
+# release is installed. The last key is the default when no docker_version is
+# requested.
 docker_version_map:
   "24.0":
     package:
       - docker-ce=5:24.0.*
       - docker-ce-cli=5:24.0.*
       - containerd.io
-    repo: deb https://download.docker.com/linux/ubuntu focal stable
+    repo: deb https://download.docker.com/linux/ubuntu jammy stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      id: 0EBFCD88
+  "25.0":
+    package:
+      - docker-ce=5:25.0.*
+      - docker-ce-cli=5:25.0.*
+      - containerd.io
+    repo: deb https://download.docker.com/linux/ubuntu jammy stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
       id: 0EBFCD88


### PR DESCRIPTION
## Summary

Hardens the role so it can install Elastic Cloud Enterprise end-to-end on **Rocky 9 with Podman 5** and on **Ubuntu 22.04 with Docker 25.0**. Each change below fixes a concrete install-time or runtime failure and is guarded so existing setups are unaffected.

## 1. Private-registry credentials on Podman, and for runtime pulls

- **`tasks/ece-bootstrap/main.yml`** — `~/.docker` and `~/.docker/config.json` were provisioned only when `container_engine == "Docker"`. Podman also reads `~/.docker/config.json` (via its auth fallback chain), so they are now provisioned for **both** runtimes whenever a `docker_config` is supplied (`docker_config != ""`). Without this, Podman hosts have no credentials and pulls from private registries fail. No change for Docker hosts; public-only installs (`docker_config = ""`) still write nothing.
- **`templates/registry-auth.conf.j2` (new) + `--config-file` in `primary/`+`secondary/install_stack.yml`** — the installer only exposes the host docker config for the *initial* host-side image pull. The long-lived runner and allocator containers that pull images at runtime (stack images, and the data-copier used during moves) never see it, so those runtime pulls fail with `PullAccessDenied` against private registries. This adds a container-config mutation that bind-mounts the host's docker config dir (`ece_docker_config_dir`, default `/home/elastic/.docker`; the container-side target is always `/home/elastic/.docker`, the elastic user's home inside the ECE images) into the runner and allocator containers, passed to the installer via `--config-file` (only when `docker_config` is set). This behaviour is documented in a new README "Private Docker registry authentication" section. The mutation key must be `DEV`: ECE parses every other mutation key as a platform version (`PlatformVersion.fromString`), which aborts the install with *"No result when parsing failed"*; the `DEV` bucket is the version-agnostic, always-applied mutation.

## 2. Podman 5 on Rocky 9, version pinning, and CNI networking

- **`vars/os_Rocky_9.yml` + `tasks/base/Rocky-9/install_podman.yml` + `tasks/base/main.yml`** — the version map is re-keyed by major (`4`, `5`) using dnf globs so the latest patch of the chosen major is installed (matching the ECE docs `dnf install podman-<major>.*`), defaulting to Podman 5. An explicit version (e.g. `podman_version=5.2.3`) is also accepted and installed literally; the version assert and the `default(...)` fallback now tolerate that (and an empty string).
- **`tasks/base/Rocky-9/configure_cni_network.yml` (new), wired in `Rocky-9/main.yml`** — Rocky 9 Podman defaults to the netavark backend, but ECE's allocator networking requires the legacy CNI backend. Installs `containernetworking-plugins` and sets `network_backend = "cni"`.

## 3. Store container images on the data volume

- **`tasks/base/general/configure_podman.yml` + `setup_mount_permissions.yml`** — Podman defaults its image store (`graphroot`) to the (small) OS root disk; the large ECE stack images exhaust it and pulls fail with *"no space left on device"*. Relocate **only `graphroot`** to `{{ data_dir }}/docker` (the Podman equivalent of Docker's `--data-root`), and create that directory after the data volume mounts. `runroot` is intentionally left at Podman's default (`/run/containers/storage`, a tmpfs): it holds ephemeral runtime state that must be cleared on reboot, so it should not live on the persistent volume. Also installs a `/usr/bin/docker` → `podman-remote` shim pointed at the same rootful socket ECE uses, since the ECE Podman docs expect a `docker` command to exist for operator/diagnostic use.

## 4. Docker 25.0 on Ubuntu 22.04 + open-file limit

- **`vars/os_Ubuntu_22.yml`** — add Docker `25.0` to the version map and correct the apt repo suite to `jammy` (was `focal`); majors are pinned via apt globs.
- **`defaults/main.yml` + `templates/docker.conf`** — add `docker_default_nofile` and pass `--default-ulimit nofile`. Docker ≤ 24 implicitly injected a large nofile default; Docker 25.0 removed it, so containers inherited the host's `1024` soft limit and ECE's preflight check failed.

## 5. Robust ECE data-device selection

- **`defaults/main.yml` + `tasks/direct-install/setup_xfs.yml` + `README.md`** — the `device_name` default (`xvdb`) is removed; formatting a disk is destructive, so the role no longer guesses. Provide `device_name` explicitly (an absolute path such as `/dev/disk/by-id/nvme-...` is used as-is; a bare name resolves under `/dev/`), or opt into `ece_data_device_autodetect`, which only auto-selects when there is **exactly one** unused whole disk and **fails (listing candidates)** if it finds zero or more than one, rather than silently formatting whichever sorts first. The role asserts a device is defined and uses it for the LVM PV. This avoids formatting the wrong disk when unstable kernel names (e.g. `nvme1n1`) are reassigned across reboots/instances.

## 6. Honor `capacity` on the installer

- **`tasks/ece-bootstrap/primary/install_stack.yml`** — the primary install now passes `--capacity {{ capacity }}` when `capacity` is defined (the secondary already did). Without it ECE auto-detects a smaller allocator capacity, which can cause move/vacate operations to fail with `NotEnoughCapacity`.

## 7. Surface installer errors

- **`tasks/ece-bootstrap/primary/install_stack.yml`** — the async install monitor is wrapped in a `block`/`rescue` that dumps the installer's async result and the on-disk bootstrap logs on failure, plus a step that greps error-like lines from `bootstrap.log` (credential-filtered). Previously a failed/aborted install surfaced only as an opaque *"cannot open bootstrap.log"* or a downstream *"secrets file missing"*.

## Test plan

Manually tested by installing full ECE environments with this role on both container runtimes and running the ECE integration-test suite against them:

- [x] **Podman environment (Rocky 9 / Podman 5)** — full install with a `docker_config` for a private registry: `config.json` provisioned for `elastic`, images pull over the CNI backend, install completes, and move/vacate operations (which pull the data-copier at runtime) succeed.
- [x] **Docker environment (Ubuntu 22.04 / Docker 25.0)** — full install completes and the nofile preflight passes.
- [x] Both environments run the ECE integration-test suite green (registry-auth mutation, capacity, and data-volume storage all exercised end-to-end).

Made with [Cursor](https://cursor.com)


