### PR TITLE
fix: update pinned containerd.io versions to patched releases available upstream

### DIFF
--- a/vars/os_CentOS_7.yml
+++ b/vars/os_CentOS_7.yml
@@ -12,7 +12,7 @@ docker_version_map:
     package:
       - docker-ce-18.09.9
       - docker-ce-cli-18.09.9
-      - containerd.io-1.4.3
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg
@@ -21,7 +21,7 @@ docker_version_map:
     package:
       - docker-ce-20.10.8
       - docker-ce-cli-20.10.8
-      - containerd.io-1.4.3
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_CentOS_8.yml
+++ b/vars/os_CentOS_8.yml
@@ -12,7 +12,7 @@ docker_version_map:
     package:
       - docker-ce-19.03.15
       - docker-ce-cli-19.03.15
-      - containerd.io-1.4.3
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/8/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg
@@ -22,7 +22,7 @@ docker_version_map:
     package:
       - docker-ce-20.10.8
       - docker-ce-cli-20.10.8
-      - containerd.io-1.4.3
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/8/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_RedHat_7.yml
+++ b/vars/os_RedHat_7.yml
@@ -16,7 +16,7 @@ docker_version_map:
     package:
       - docker-ce-20.10.8
       - docker-ce-cli-20.10.8
-      - containerd.io-1.4.3
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/7/x86_64/stable
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -14,7 +14,7 @@ docker_version_map:
     package:
       - docker-ce-19.03.13
       - docker-ce-cli-19.03.13
-      - containerd.io-1.5.11
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/docker-ce.repo
     keys:
       server: https://download.docker.com/linux/centos/gpg
@@ -24,7 +24,7 @@ docker_version_map:
     package:
       - docker-ce-20.10.8
       - docker-ce-cli-20.10.8
-      - containerd.io-1.5.11
+      - containerd.io-1.6.28
     repo: https://download.docker.com/linux/centos/docker-ce.repo
     keys:
       server: https://download.docker.com/linux/centos/gpg

--- a/vars/os_Ubuntu_16.yml
+++ b/vars/os_Ubuntu_16.yml
@@ -6,12 +6,15 @@ conntrack_module: ip_conntrack
 container_engine: Docker
 
 # Docker version mapping
+# NOTE: Ubuntu 16.04 (xenial) is EOL and Docker's xenial apt pool is frozen;
+# containerd.io 1.4.6 is the last build published for xenial
+# (https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/).
 docker_version_map:
   "18.09":
     package:
       - docker-ce=5:18.09.9*
       - docker-ce-cli=5:18.09.9*
-      - containerd.io=1.4.3-1*
+      - containerd.io=1.4.6-1*
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
@@ -20,7 +23,7 @@ docker_version_map:
     package:
       - docker-ce=5:19.03.15*
       - docker-ce-cli=5:19.03.15*
-      - containerd.io=1.4.3-1*
+      - containerd.io=1.4.6-1*
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu xenial stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg

--- a/vars/os_Ubuntu_18.yml
+++ b/vars/os_Ubuntu_18.yml
@@ -6,12 +6,14 @@ conntrack_module: xt_conntrack
 container_engine: Docker
 
 # Docker version mapping
+# NOTE: containerd.io 1.6.21 is the last build published in Docker's bionic apt pool
+# (https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/).
 docker_version_map:
   "19.03":
     package:
       - docker-ce=5:19.03.15*
       - docker-ce-cli=5:19.03.15*
-      - containerd.io=1.4.3-1*
+      - containerd.io=1.6.21-1*
     repo: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg

--- a/vars/os_Ubuntu_22.yml
+++ b/vars/os_Ubuntu_22.yml
@@ -10,12 +10,16 @@ container_engine: Docker
 #   "24.0" / "25.0" — that minor line only (apt glob N.0.*)
 # Docker 24 and 25 only shipped a .0 line, so the two globs resolve the same
 # today. The last key is the default when no docker_version is requested.
+# NOTE: containerd.io is pinned to 1.7.* because Docker's jammy apt pool
+# (https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/)
+# now also publishes containerd 2.x, which does not pair with the Docker
+# 24/25 line installed here. The glob tracks the latest 1.7.x patch build.
 docker_version_map:
   "24.0":
     package:
       - docker-ce=5:24.0.*
       - docker-ce-cli=5:24.0.*
-      - containerd.io
+      - containerd.io=1.7.*
     repo: deb https://download.docker.com/linux/ubuntu jammy stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
@@ -24,7 +28,7 @@ docker_version_map:
     package:
       - docker-ce=5:24.*
       - docker-ce-cli=5:24.*
-      - containerd.io
+      - containerd.io=1.7.*
     repo: deb https://download.docker.com/linux/ubuntu jammy stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
@@ -33,7 +37,7 @@ docker_version_map:
     package:
       - docker-ce=5:25.0.*
       - docker-ce-cli=5:25.0.*
-      - containerd.io
+      - containerd.io=1.7.*
     repo: deb https://download.docker.com/linux/ubuntu jammy stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
@@ -42,7 +46,7 @@ docker_version_map:
     package:
       - docker-ce=5:25.*
       - docker-ce-cli=5:25.*
-      - containerd.io
+      - containerd.io=1.7.*
     repo: deb https://download.docker.com/linux/ubuntu jammy stable
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg


### PR DESCRIPTION
## Summary

Updates the pinned `containerd.io` versions in `vars/os_*.yml` from EOL builds with known CVEs (1.4.3 everywhere, 1.5.11 on RHEL 8) to the newest builds actually published in Docker's package repos for each distro.

This addresses elastic/cp-hosted-team#590, which stems from Sev 1 SDH elastic/sdh-control-plane#6989: a customer used this playbook for a RHEL 7 → 8 upgrade and the ancient pinned containerd broke their containers. It also brings the playbook in line with the ECE host-configuration docs, which recommend installing a current containerd.io alongside the supported Docker versions.

## Supersedes / revives #218

PR #218 correctly moved CentOS 7/8 and RHEL 7/8 to `containerd.io-1.6.28`, but the blocking review found it also pinned Ubuntu 16/18 to `1.6.28-1*`, which was never published in Docker's xenial/bionic apt pools and would make `apt-get install` fail on exactly the OSes being fixed. This PR keeps 1.6.28 for the yum-based distros and pins Ubuntu 16/18 to the highest versions actually available in their pools, per the review's suggested fix.

## Verified available versions (checked 2026-08-19)

| Distro | File | Old pin | New pin | Highest available upstream | Verified against |
| --- | --- | --- | --- | --- | --- |
| CentOS 7 | `vars/os_CentOS_7.yml` | 1.4.3 | **1.6.28** | 1.6.33 (el7, repo frozen) | https://download.docker.com/linux/centos/7/x86_64/stable/Packages/ |
| CentOS 8 | `vars/os_CentOS_8.yml` | 1.4.3 | **1.6.28** | ≥ 1.6.32 (el8) | https://download.docker.com/linux/centos/8/x86_64/stable/Packages/ |
| RHEL 7 | `vars/os_RedHat_7.yml` | 1.4.3 | **1.6.28** | 1.6.33 (uses the centos/7 repo configured in this file) | https://download.docker.com/linux/centos/7/x86_64/stable/Packages/ |
| RHEL 8 | `vars/os_RedHat_8.yml` | 1.5.11 | **1.6.28** | ≥ 1.6.32 (uses `centos/docker-ce.repo` → el8 packages) | https://download.docker.com/linux/centos/8/x86_64/stable/Packages/ |
| Ubuntu 18.04 (bionic) | `vars/os_Ubuntu_18.yml` | 1.4.3-1\* | **1.6.21-1\*** | 1.6.21 (last bionic build, 2023-05) | https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/ |
| Ubuntu 16.04 (xenial, EOL) | `vars/os_Ubuntu_16.yml` | 1.4.3-1\* | **1.4.6-1\*** | 1.4.6 (pool frozen, 2021-05) | https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/ |
| Ubuntu 22.04 (jammy) | `vars/os_Ubuntu_22.yml` | unpinned (`containerd.io`) | **1.7.\*** (all four map entries) | 1.7.29; jammy also ships 2.1–2.3.x, which is why the pin is needed (checked 2026-09-11) | https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/ |

Notes:
- **Rebased onto current master (2026-09-11)** per review: #224's rewrite of `vars/os_RedHat_8.yml` (Podman 4 map, dual-engine comments) is preserved as-is; only the two Docker-map `containerd.io-1.5.11` pins were swapped to `1.6.28`. The Ubuntu 22 pin covers all four map entries ("24.0"/"24"/"25.0"/"25") that exist after #225.
- 1.6.28 is kept for the yum-based distros (rather than the absolute latest 1.6.3x) for consistency with #218 and the ECE docs recommendations; newer el7/el8 builds do exist if reviewers prefer them.
- Comments were added to the Ubuntu 16/18/22 vars files explaining why those pins are capped, so this doesn't regress in a future "bump everything" pass.
- Ubuntu 20 remains unpinned (bare `containerd.io`): focal's pool tops out at containerd 1.7.27, so there is no 2.x exposure there — per review, left out of scope.
- Centralizing the version into a single shared var (also raised in the #218 review as non-blocking) is left as a follow-up to keep this fix minimal.

## Testing

- `ansible-lint` on the role: exit 0 (only pre-existing galaxy `role-name` metadata warnings, unrelated).
- `yamllint` on the changed files: no errors (pre-existing style warnings only).
- `ansible-playbook --syntax-check` on a wrapper playbook including this role: passes.
- YAML-parsed all changed vars files and asserted the resulting `docker_version_map` package pins.
- Verified every new pin exists upstream via the repo listings linked in the table above.

Closes elastic/cp-hosted-team#590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

