### PR TITLE
Add Ubuntu 24, RHEL 8 Podman, SLES 15 Docker 25/29, and RHEL 9 Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please note that the ECE Ansible playbook is a community project supported by El
 
 This role is tested against Ansible 2.8.7.
 
-Supported container-engine hosts include Ubuntu (Docker), SLES (Docker), Rocky 8/9 (Podman), and RHEL 9 (Podman). RHEL 10 Podman support is experimental in this role (`ece_os_experimental`) and is not listed in Galaxy yet.
+Supported container-engine hosts include Ubuntu 20.04/22.04/24.04 (Docker), SLES 15 (Docker), Rocky 8/9 (Podman), RHEL 8 (Docker or Podman), and RHEL 9 (Podman, or Docker 29). RHEL 10 Podman support is experimental in this role (`ece_os_experimental`) and is not listed in Galaxy yet.
 
 On Podman hosts the role exposes the installer socket at `/var/run/docker.sock` (official ECE RHEL prep). Older revisions of this role used `--host-docker-host /run/podman/podman.sock`. Re-running the role on a cluster installed with that older socket path moves the systemd socket without rewriting existing ECE runner config — do not treat that as a drop-in upgrade.
 
@@ -87,6 +87,11 @@ The following variables are avaible:
     - Default is `disabled` so firewalld does not block a fresh ECE install.
 - `ece_firewalld_open_ports`: firewalld ports opened when `ece_firewalld_mode=enabled`.
     - Default: empty. This role does not ship an ECE port matrix. If you enable firewalld, set the ports your install needs.
+- `ece_podman_ipv6_network`: When `true` on a Podman host, create a dual-stack default network (`ece_podman_network_name`) so ECE containers get an IPv6 address.
+    - Default: `false`
+- `ece_podman_network_name`: Name of the optional dual-stack Podman network.
+    - Default: `ece-network`
+- `ece_podman_network_ipv4_subnet` / `ece_podman_network_ipv6_subnet`: Subnets used when `ece_podman_ipv6_network` is true.
 - `ece_roles`: Elastic Cloud Enterprise roles that successive hosts should assume
     - Default: [director, coordinator, proxy, allocator]
 - `capacity`: [Amount of memory to grant to the allocator](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-capacity.html#ece-alloc-memory)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please note that the ECE Ansible playbook is a community project supported by El
 
 This role is tested against Ansible 2.8.7.
 
-Supported container-engine hosts include Ubuntu 20.04/22.04/24.04 (Docker), SLES 15 (Docker), Rocky 8/9 (Podman), RHEL 8 (Docker or Podman), and RHEL 9 (Podman, or Docker 29). RHEL 10 Podman support is experimental in this role (`ece_os_experimental`) and is not listed in Galaxy yet.
+Supported container-engine hosts include Ubuntu 20.04/22.04/24.04 (Docker), SLES 15 (Docker), Rocky 8/9 (Podman), RHEL 8 (Docker or Podman), and RHEL 9 (Podman). RHEL 9 with Docker and RHEL 10 with Podman are experimental in this role (not official support-matrix combinations) and emit a warning at runtime. RHEL 10 is also not listed in Galaxy yet.
 
 On Podman hosts the role exposes the installer socket at `/var/run/docker.sock` (official ECE RHEL prep). Older revisions of this role used `--host-docker-host /run/podman/podman.sock`. Re-running the role on a cluster installed with that older socket path moves the systemd socket without rewriting existing ECE runner config — do not treat that as a drop-in upgrade.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please note that the ECE Ansible playbook is a community project supported by El
 
 This role is tested against Ansible 2.8.7.
 
-Supported container-engine hosts include Ubuntu 20.04/22.04/24.04 (Docker), SLES 15 (Docker), Rocky 8/9 (Podman), RHEL 8 (Docker or Podman), and RHEL 9 (Podman). RHEL 9 with Docker and RHEL 10 with Podman are experimental in this role (not official support-matrix combinations) and emit a warning at runtime. RHEL 10 is also not listed in Galaxy yet.
+Supported container-engine hosts include Ubuntu 16.04/20.04/22.04/24.04 (Docker), SLES 15 (Docker), Rocky 8/9 (Podman), RHEL 8 (Docker or Podman), and RHEL 9 (Podman). RHEL 9 with Docker and RHEL 10 with Podman are experimental in this role (not official support-matrix combinations) and emit a warning at runtime. RHEL 10 is also not listed in Galaxy yet.
 
 On Podman hosts the role exposes the installer socket at `/var/run/docker.sock` (official ECE RHEL prep). Older revisions of this role used `--host-docker-host /run/podman/podman.sock`. Re-running the role on a cluster installed with that older socket path moves the systemd socket without rewriting existing ECE runner config — do not treat that as a drop-in upgrade.
 
@@ -94,6 +94,12 @@ The following variables are avaible:
     - Default: `ece-network`
 - `ece_podman_network_ipv4_subnet` / `ece_podman_network_ipv6_subnet`: Subnets used when
   `ece_podman_ipv6_network` is true.
+- `ece_docker_ipv6`: When `true` on a Docker host, merge `ipv6` / `fixed-cidr-v6` / `ip6tables`
+  into `/etc/docker/daemon.json` (official Ubuntu/SLES dual-stack host-prep). Existing keys
+  in that file are kept.
+    - Default: `false`
+- `ece_docker_ipv6_cidr`: IPv6 subnet written when `ece_docker_ipv6` is true.
+    - Default: `fd00:10:89::/64`
 - `ece_roles`: Elastic Cloud Enterprise roles that successive hosts should assume
     - Default: [director, coordinator, proxy, allocator]
 - `capacity`: [Amount of memory to grant to the allocator](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-capacity.html#ece-alloc-memory)

--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ The following variables are avaible:
     - Default is `disabled` so firewalld does not block a fresh ECE install.
 - `ece_firewalld_open_ports`: firewalld ports opened when `ece_firewalld_mode=enabled`.
     - Default: empty. This role does not ship an ECE port matrix. If you enable firewalld, set the ports your install needs.
-- `ece_podman_ipv6_network`: When `true` on a Podman host, create a dual-stack default network (`ece_podman_network_name`) so ECE containers get an IPv6 address.
+- `ece_podman_ipv6_network`: When `true` on a Podman host, create a dual-stack default network
+  (`ece_podman_network_name`) so ECE containers get an IPv6 address.
     - Default: `false`
 - `ece_podman_network_name`: Name of the optional dual-stack Podman network.
     - Default: `ece-network`
-- `ece_podman_network_ipv4_subnet` / `ece_podman_network_ipv6_subnet`: Subnets used when `ece_podman_ipv6_network` is true.
+- `ece_podman_network_ipv4_subnet` / `ece_podman_network_ipv6_subnet`: Subnets used when
+  `ece_podman_ipv6_network` is true.
 - `ece_roles`: Elastic Cloud Enterprise roles that successive hosts should assume
     - Default: [director, coordinator, proxy, allocator]
 - `capacity`: [Amount of memory to grant to the allocator](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-capacity.html#ece-alloc-memory)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,14 @@ ece_selinux_mode: disabled
 ece_firewalld_mode: disabled
 ece_firewalld_open_ports: []
 
+# Optional dual-stack default network on Podman hosts (IPv6). Off by default.
+# When true, the role creates ece_podman_network_name with both subnets and
+# sets it as Podman's default_network before ECE is installed.
+ece_podman_ipv6_network: false
+ece_podman_network_name: ece-network
+ece_podman_network_ipv4_subnet: "10.89.0.0/24"
+ece_podman_network_ipv6_subnet: "fd00:10:89::/64"
+
 
 # Elastic Cloud Enterprise - Support Diagnostics Settings
 ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.3.tar.gz"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,7 @@ docker_bridge_ip: "172.17.42.1/16"
 docker_default_nofile: 1024000
 
 
-# User and group id, uncomment if needed to override.
-# elastic_uid: 1234
-# elastic_gid: 1234
+# Optional. Official docs use `useradd` without -u/-g so the OS assigns
+# UID/GID >= 1000. Set these only to pin a specific id.
+# elastic_uid:
+# elastic_gid:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,11 @@ ece_podman_network_name: ece-network
 ece_podman_network_ipv4_subnet: "10.89.0.0/24"
 ece_podman_network_ipv6_subnet: "fd00:10:89::/64"
 
+# Optional Docker dual-stack default bridge (IPv6). Off by default. When true, the role merges
+# ipv6 / fixed-cidr-v6 / ip6tables into /etc/docker/daemon.json (official Ubuntu/SLES host-prep).
+ece_docker_ipv6: false
+ece_docker_ipv6_cidr: "fd00:10:89::/64"
+
 
 # Elastic Cloud Enterprise - Support Diagnostics Settings
 ece_supportdiagnostics_url: "https://github.com/elastic/ece-support-diagnostics/archive/v1.3.tar.gz"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,9 +74,9 @@ ece_selinux_mode: disabled
 ece_firewalld_mode: disabled
 ece_firewalld_open_ports: []
 
-# Optional dual-stack default network on Podman hosts (IPv6). Off by default.
-# When true, the role creates ece_podman_network_name with both subnets and
-# sets it as Podman's default_network before ECE is installed.
+# Optional dual-stack default network on Podman hosts (IPv6). Off by default. When true, the role
+# creates ece_podman_network_name with both subnets and sets it as Podman's default_network before
+# ECE is installed.
 ece_podman_ipv6_network: false
 ece_podman_network_name: ece-network
 ece_podman_network_ipv4_subnet: "10.89.0.0/24"
@@ -99,7 +99,7 @@ docker_bridge_ip: "172.17.42.1/16"
 docker_default_nofile: 1024000
 
 
-# Optional. Official docs use `useradd` without -u/-g so the OS assigns
-# UID/GID >= 1000. Set these only to pin a specific id.
+# Optional. Official docs use `useradd` without -u/-g so the OS assigns UID/GID >= 1000. Set these
+# only to pin a specific id.
 # elastic_uid:
 # elastic_gid:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,15 +9,19 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - 16.04
+    - 20.04
     - 22.04
+    - 24.04
   - name: SLES
     versions:
+    - 15
   - name: Rocky
     versions:
     - 8
     - 9
   - name: EL
     versions:
+    - 8
     - 9
 
 dependencies: []

--- a/tasks/base/RedHat-8/configure_cni_network.yml
+++ b/tasks/base/RedHat-8/configure_cni_network.yml
@@ -1,0 +1,22 @@
+---
+# RHEL 8 Podman uses the CNI network backend. Install the plugins and pin
+# network_backend so ECE allocator networking matches the on-prem docs.
+- name: Install CNI plugins (required for the cni network backend)
+  package:
+    name: containernetworking-plugins
+    state: present
+
+- name: Ensure /etc/containers/containers.conf exists
+  copy:
+    src: /usr/share/containers/containers.conf
+    dest: /etc/containers/containers.conf
+    remote_src: true
+    force: false
+
+- name: Use the CNI network backend for Podman
+  ini_file:
+    path: /etc/containers/containers.conf
+    section: network
+    option: network_backend
+    value: '"cni"'
+    no_extra_spaces: true

--- a/tasks/base/RedHat-8/configure_cni_network.yml
+++ b/tasks/base/RedHat-8/configure_cni_network.yml
@@ -1,6 +1,6 @@
 ---
-# RHEL 8 Podman uses the CNI network backend. Install the plugins and pin
-# network_backend so ECE allocator networking matches the on-prem docs.
+# RHEL 8 Podman uses the CNI network backend. Install the plugins and pin network_backend so ECE
+# allocator networking matches the on-prem docs.
 - name: Install CNI plugins (required for the cni network backend)
   package:
     name: containernetworking-plugins

--- a/tasks/base/RedHat-8/install_dependencies.yml
+++ b/tasks/base/RedHat-8/install_dependencies.yml
@@ -6,3 +6,7 @@
   with_items:
   - lvm2
   - iptables
+  - sysstat
+  - net-tools
+  - containernetworking-plugins
+  - policycoreutils-python-utils

--- a/tasks/base/RedHat-8/install_dependencies.yml
+++ b/tasks/base/RedHat-8/install_dependencies.yml
@@ -8,5 +8,4 @@
   - iptables
   - sysstat
   - net-tools
-  - containernetworking-plugins
   - policycoreutils-python-utils

--- a/tasks/base/RedHat-8/install_podman.yml
+++ b/tasks/base/RedHat-8/install_podman.yml
@@ -1,0 +1,29 @@
+---
+- name: Configure SELinux mode for Podman hosts
+  ansible.posix.selinux:
+    state: "{{ ece_selinux_mode }}"
+    policy: "{{ 'targeted' if ece_selinux_mode != 'disabled' else omit }}"
+  when: ece_selinux_mode != "os-default"
+
+# A podman_version that matches a podman_version_map key installs the latest
+# patch of that major via a dnf glob (e.g. "4" -> podman-4.* / podman-remote-4.*).
+# Any other value is treated as an explicit version so a specific release can be
+# pinned, e.g. podman_version=4.9.4 -> podman-4.9.4* / podman-remote-4.9.4*.
+- name: Resolve Podman packages
+  set_fact:
+    podman_packages: >-
+      {{ podman_version_map[podman_version]['package']
+         if podman_version in podman_version_map
+         else ['podman-' ~ podman_version ~ '*', 'podman-remote-' ~ podman_version ~ '*'] }}
+
+- name: Install Podman
+  package:
+    name: "{{ podman_packages }}"
+    state: present
+
+- name: Verify that fs.may_detach_mounts is enabled
+  lineinfile:
+    path: /etc/sysctl.conf
+    regexp: '^fs.may_detach_mounts'
+    line: 'fs.may_detach_mounts = 1'
+    create: yes

--- a/tasks/base/RedHat-8/install_podman.yml
+++ b/tasks/base/RedHat-8/install_podman.yml
@@ -5,10 +5,10 @@
     policy: "{{ 'targeted' if ece_selinux_mode != 'disabled' else omit }}"
   when: ece_selinux_mode != "os-default"
 
-# A podman_version that matches a podman_version_map key installs the latest
-# patch of that major via a dnf glob (e.g. "4" -> podman-4.* / podman-remote-4.*).
-# Any other value is treated as an explicit version so a specific release can be
-# pinned, e.g. podman_version=4.9.4 -> podman-4.9.4* / podman-remote-4.9.4*.
+# A podman_version that matches a podman_version_map key installs the latest patch of that major
+# via a dnf glob (e.g. "4" -> podman-4.* / podman-remote-4.*). Any other value is treated as an
+# explicit version so a specific release can be pinned, e.g. podman_version=4.9.4 ->
+# podman-4.9.4* / podman-remote-4.9.4*.
 - name: Resolve Podman packages
   set_fact:
     podman_packages: >-

--- a/tasks/base/RedHat-8/main.yml
+++ b/tasks/base/RedHat-8/main.yml
@@ -1,11 +1,13 @@
 ---
-- name: Disable firewalld
-  systemd:
-    name: firewalld
-    state: stopped
-    enabled: no
-  ignore_errors: true
+- ansible.builtin.include_tasks: "{{ role_path }}/tasks/base/general/manage_firewalld.yml"
 
 - include_tasks: install_dependencies.yml
 - include_tasks: install_docker.yml
   tags: [install_docker, destructive]
+  when: container_engine == "Docker"
+- include_tasks: install_podman.yml
+  tags: [install_podman, install_docker, destructive]
+  when: container_engine == "Podman"
+- include_tasks: configure_cni_network.yml
+  tags: [install_podman, install_docker, destructive]
+  when: container_engine == "Podman"

--- a/tasks/base/RedHat-9/install_docker.yml
+++ b/tasks/base/RedHat-9/install_docker.yml
@@ -1,0 +1,79 @@
+---
+- name: Configure SELinux mode for Docker hosts
+  ansible.posix.selinux:
+    state: "{{ ece_selinux_mode }}"
+    policy: "{{ 'targeted' if ece_selinux_mode != 'disabled' else omit }}"
+  when: ece_selinux_mode != "os-default"
+
+- name: Remove conflicting container engines
+  package:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+    - docker
+    - docker-ce
+    - podman
+    - podman-remote
+  register: remove_packages
+  retries: 10
+  delay: 30
+  until: remove_packages is success
+
+- name: Add Docker GPG Key
+  rpm_key:
+    key: "{{ docker_version_map[docker_version]['keys']['server'] }}"
+    state: present
+
+- name: Add Docker CE repository
+  command: dnf config-manager --add-repo="{{ docker_version_map[docker_version]['repo'] }}"
+  args:
+    creates: /etc/yum.repos.d/docker-ce.repo
+  register: repo_installed
+  retries: 10
+  delay: 30
+  until: repo_installed is success
+
+- name: Install docker
+  package:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    state: present
+
+- name: Verify that fs.may_detach_mounts is enabled
+  lineinfile:
+    path: /etc/sysctl.conf
+    regexp: '^fs.may_detach_mounts'
+    line: 'fs.may_detach_mounts = 1'
+    create: yes
+
+# Docker 28+ needs ip_set for iptables port publishing. ECE's allocator talks
+# to the ip_tables kernel API (libiptc) even when the host userspace is nft.
+- name: Load iptables compatibility modules for Docker and ECE
+  copy:
+    dest: "/etc/modules-load.d/{{ item }}.conf"
+    content: "{{ item }}\n"
+  loop:
+    - ip_set
+    - ip_tables
+    - iptable_nat
+    - iptable_filter
+
+- name: Ensure iptables compatibility modules are loaded now
+  modprobe:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - ip_set
+    - ip_tables
+    - iptable_nat
+    - iptable_filter
+  failed_when: false
+
+- name: Point iptables alternatives at nft
+  alternatives:
+    name: "{{ item.name }}"
+    path: "{{ item.path }}"
+  loop:
+    - { name: iptables, path: /usr/sbin/iptables-nft }
+    - { name: ip6tables, path: /usr/sbin/ip6tables-nft }
+  failed_when: false

--- a/tasks/base/RedHat-9/install_docker.yml
+++ b/tasks/base/RedHat-9/install_docker.yml
@@ -46,8 +46,8 @@
     line: 'fs.may_detach_mounts = 1'
     create: yes
 
-# Docker 28+ needs ip_set for iptables port publishing. ECE's allocator talks
-# to the ip_tables kernel API (libiptc) even when the host userspace is nft.
+# Docker 28+ needs ip_set for iptables port publishing. ECE's allocator talks to the ip_tables
+# kernel API (libiptc) even when the host userspace is nft.
 - name: Load iptables compatibility modules for Docker and ECE
   copy:
     dest: "/etc/modules-load.d/{{ item }}.conf"

--- a/tasks/base/RedHat-9/install_docker.yml
+++ b/tasks/base/RedHat-9/install_docker.yml
@@ -25,10 +25,13 @@
     key: "{{ docker_version_map[docker_version]['keys']['server'] }}"
     state: present
 
+# Download the vendor .repo file. Avoid `dnf config-manager` so this works on
+# minimal RHEL 9 images that do not ship dnf-plugins-core.
 - name: Add Docker CE repository
-  command: dnf config-manager --add-repo="{{ docker_version_map[docker_version]['repo'] }}"
-  args:
-    creates: /etc/yum.repos.d/docker-ce.repo
+  get_url:
+    url: "{{ docker_version_map[docker_version]['repo'] }}"
+    dest: /etc/yum.repos.d/docker-ce.repo
+    mode: "0644"
   register: repo_installed
   retries: 10
   delay: 30

--- a/tasks/base/RedHat-9/main.yml
+++ b/tasks/base/RedHat-9/main.yml
@@ -10,4 +10,8 @@
   tags: [install_podman, install_docker, destructive]
   when: container_engine == "Podman"
 
+- ansible.builtin.include_tasks: install_docker.yml
+  tags: [install_docker, destructive]
+  when: container_engine == "Docker"
+
 

--- a/tasks/base/SLES-15/install_docker.yml
+++ b/tasks/base/SLES-15/install_docker.yml
@@ -12,13 +12,85 @@
   delay: 30
   until: remove_packages is success
 
-- name: Install docker
+- name: Install docker from the SLES zypper package
   command: "zypper install -y --force-resolution --replacefiles {{ docker_version_map[docker_version]['package'] }} acl"
   args:
     warn: false
+  when: docker_version_map[docker_version]['method'] | default('zypper') == 'zypper'
+
+- name: Install docker from the official static tarball
+  when: docker_version_map[docker_version]['method'] | default('zypper') == 'static'
+  block:
+    - name: Install static-docker runtime dependencies
+      zypper:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+        - runc
+        - containerd
+        - fuse-overlayfs
+        - slirp4netns
+        - libseccomp2
+        - iptables
+        - acl
+      register: static_deps
+      retries: 10
+      delay: 30
+      until: static_deps is success
+
+    - name: Download Docker static binary tarball
+      get_url:
+        url: "https://download.docker.com/linux/static/stable/{{ ansible_architecture }}/docker-{{ docker_version_map[docker_version]['tarball_version'] }}.tgz"
+        dest: "/tmp/docker-{{ docker_version_map[docker_version]['tarball_version'] }}.tgz"
+        mode: "0644"
+
+    - name: Extract Docker static binaries into /usr/bin
+      unarchive:
+        src: "/tmp/docker-{{ docker_version_map[docker_version]['tarball_version'] }}.tgz"
+        dest: /usr/bin
+        remote_src: true
+        extra_opts:
+          - --strip-components=1
+
+    - name: Install systemd unit for static dockerd
+      copy:
+        dest: /etc/systemd/system/docker.service
+        mode: "0644"
+        owner: root
+        group: root
+        content: |
+          [Unit]
+          Description=Docker Application Container Engine
+          Documentation=https://docs.docker.com
+          After=network-online.target firewalld.service
+          Wants=network-online.target
+
+          [Service]
+          Type=notify
+          ExecStart=/usr/bin/dockerd
+          ExecReload=/bin/kill -s HUP $MAINPID
+          TimeoutSec=0
+          RestartSec=2
+          Restart=always
+          LimitNOFILE=infinity
+          LimitNPROC=infinity
+          LimitCORE=infinity
+          TasksMax=infinity
+          Delegate=yes
+          KillMode=process
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Enable docker service unit
+      systemd:
+        name: docker
+        enabled: yes
+        daemon_reload: yes
 
 # Workaround for https://github.com/elastic/ansible-elastic-cloud-enterprise/issues/155#issuecomment-1117069430
-- name: Uninstall nscd 
+- name: Uninstall nscd
   zypper:
     name: nscd
     state: absent

--- a/tasks/base/Ubuntu-20/install_docker.yml
+++ b/tasks/base/Ubuntu-20/install_docker.yml
@@ -15,5 +15,4 @@
     update_cache: yes
     state: present
 
-- name: Pin docker-engine packet
-  shell: echo "docker-engine hold" | sudo dpkg --set-selections
+- include_tasks: ../general/hold_docker_ce.yml

--- a/tasks/base/Ubuntu-22/install_docker.yml
+++ b/tasks/base/Ubuntu-22/install_docker.yml
@@ -34,5 +34,4 @@
     update_cache: yes
     state: present
 
-- name: Pin docker-engine packet
-  shell: echo "docker-engine hold" | sudo dpkg --set-selections
+- include_tasks: ../general/hold_docker_ce.yml

--- a/tasks/base/Ubuntu-24/install_dependencies.yml
+++ b/tasks/base/Ubuntu-24/install_dependencies.yml
@@ -1,0 +1,17 @@
+---
+- name: Install base dependencies
+  apt:
+    name: "{{ packages }}"
+    update_cache: yes
+    install_recommends: yes
+    state: present
+  register: apt_res
+  retries: 3
+  until: apt_res is success
+  vars:
+    packages:
+    - xfsprogs
+    - acl
+    - ca-certificates
+    - curl
+    - gnupg

--- a/tasks/base/Ubuntu-24/install_docker.yml
+++ b/tasks/base/Ubuntu-24/install_docker.yml
@@ -1,0 +1,47 @@
+---
+# As per https://docs.docker.com/engine/install/ubuntu/#uninstall-old-versions
+# Ubuntu 24 removed apt-key; install the Docker signing key into /etc/apt/keyrings
+# and reference it from the repo line (signed-by=).
+- name: Remove docker
+  package:
+    name: "{{ packages }}"
+    state: absent
+  vars:
+    packages:
+    - docker.io
+    - docker-doc
+    - docker-compose
+    - docker-compose-v2
+    - podman-docker
+    - containerd
+    - runc
+  register: remove_packages
+  retries: 10
+  delay: 30
+  until: remove_packages is success
+
+- name: Ensure apt keyrings directory exists
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
+- name: Add docker repository key
+  get_url:
+    url: "{{ docker_version_map[docker_version]['keys']['server'] }}"
+    dest: "{{ docker_version_map[docker_version]['keys']['dest'] }}"
+    mode: "0644"
+
+- name: Add docker repository
+  apt_repository:
+    repo: "{{ docker_version_map[docker_version]['repo'] }}"
+    state: present
+
+- name: Install docker
+  apt:
+    name: "{{ docker_version_map[docker_version]['package'] }}"
+    update_cache: yes
+    state: present
+
+- name: Pin docker-engine packet
+  shell: echo "docker-engine hold" | sudo dpkg --set-selections

--- a/tasks/base/Ubuntu-24/install_docker.yml
+++ b/tasks/base/Ubuntu-24/install_docker.yml
@@ -1,7 +1,7 @@
 ---
 # As per https://docs.docker.com/engine/install/ubuntu/#uninstall-old-versions
-# Ubuntu 24 removed apt-key; install the Docker signing key into /etc/apt/keyrings
-# and reference it from the repo line (signed-by=).
+# Ubuntu 24 removed apt-key; install the Docker signing key into /etc/apt/keyrings and reference it
+# from the repo line (signed-by=).
 - name: Remove docker
   package:
     name: "{{ packages }}"

--- a/tasks/base/Ubuntu-24/install_docker.yml
+++ b/tasks/base/Ubuntu-24/install_docker.yml
@@ -43,5 +43,4 @@
     update_cache: yes
     state: present
 
-- name: Pin docker-engine packet
-  shell: echo "docker-engine hold" | sudo dpkg --set-selections
+- include_tasks: ../general/hold_docker_ce.yml

--- a/tasks/base/Ubuntu-24/main.yml
+++ b/tasks/base/Ubuntu-24/main.yml
@@ -1,0 +1,4 @@
+---
+- include_tasks: install_dependencies.yml
+- include_tasks: install_docker.yml
+  tags: [install_docker, destructive]

--- a/tasks/base/general/configure_docker.yml
+++ b/tasks/base/general/configure_docker.yml
@@ -47,6 +47,58 @@
     state: absent
     force: yes
 
+# Official Ubuntu/SLES host-prep puts default-ulimits in daemon.json because
+# PAM limits.conf does not apply inside containers. Merge so a pre-existing
+# file (for example IPv6 keys written by a caller) is not replaced.
+- name: Ensure /etc/docker exists
+  file:
+    path: /etc/docker
+    state: directory
+    mode: "0755"
+  when: docker_version != '1.13'
+
+- name: Stat existing Docker daemon.json
+  stat:
+    path: /etc/docker/daemon.json
+  register: ece_docker_daemon_stat
+  when: docker_version != '1.13'
+
+- name: Read existing Docker daemon.json
+  slurp:
+    path: /etc/docker/daemon.json
+  register: ece_docker_daemon_slurp
+  when:
+    - docker_version != '1.13'
+    - ece_docker_daemon_stat.stat.exists | default(false)
+
+- name: Merge ECE settings into Docker daemon.json
+  copy:
+    dest: /etc/docker/daemon.json
+    mode: "0644"
+    content: "{{ ece_docker_daemon_desired | combine(ece_docker_daemon_existing, recursive=True) | to_nice_json }}\n"
+  vars:
+    ece_docker_daemon_existing: "{{ (ece_docker_daemon_slurp.content | b64decode | from_json) if (ece_docker_daemon_stat.stat.exists | default(false)) else {} }}"
+    ece_docker_daemon_ulimits:
+      default-ulimits:
+        nofile:
+          Name: nofile
+          Hard: "{{ docker_default_nofile | int }}"
+          Soft: "{{ docker_default_nofile | int }}"
+        memlock:
+          Name: memlock
+          Hard: -1
+          Soft: -1
+        nproc:
+          Name: nproc
+          Hard: -1
+          Soft: -1
+    ece_docker_daemon_ipv6:
+      ipv6: true
+      fixed-cidr-v6: "{{ ece_docker_ipv6_cidr }}"
+      ip6tables: true
+    ece_docker_daemon_desired: "{{ ece_docker_daemon_ulimits | combine(ece_docker_daemon_ipv6 if (ece_docker_ipv6 | default(false) | bool) else {}, recursive=True) }}"
+  when: docker_version != '1.13'
+
 - name: Docker daemon is enabled and systemd has read all changes
   systemd:
     name: docker

--- a/tasks/base/general/configure_podman.yml
+++ b/tasks/base/general/configure_podman.yml
@@ -23,6 +23,44 @@
     option: graphroot
     value: '"{{ data_dir }}/docker"'
 
+- name: Ensure /etc/containers/containers.conf exists
+  copy:
+    src: /usr/share/containers/containers.conf
+    dest: /etc/containers/containers.conf
+    remote_src: true
+    force: false
+
+# Official RHEL host-prep: PAM limits.conf does not apply inside containers.
+- name: Set Podman default container ulimits
+  ini_file:
+    path: /etc/containers/containers.conf
+    section: containers
+    option: default_ulimits
+    value: '["nofile=1024000:1024000", "memlock=-1:-1", "nproc=-1:-1"]'
+    no_extra_spaces: true
+
+# Official RHEL host-prep: lock the Podman major so dnf does not jump 4 -> 5.
+- name: Install the dnf versionlock plugin
+  package:
+    name: python3-dnf-plugin-versionlock
+    state: present
+  when: ansible_pkg_mgr == "dnf"
+
+- name: List existing dnf version locks
+  command: dnf versionlock list
+  register: ece_podman_versionlock
+  changed_when: false
+  when: ansible_pkg_mgr == "dnf"
+
+- name: Lock the installed Podman major version
+  command: dnf versionlock add --raw "{{ item }}"
+  loop:
+    - "podman-{{ (podman_version | string).split('.')[0] }}.*"
+    - "podman-remote-{{ (podman_version | string).split('.')[0] }}.*"
+  when:
+    - ansible_pkg_mgr == "dnf"
+    - item not in (ece_podman_versionlock.stdout | default(''))
+
 # Not strictly needed, allows containers to run after user logout in some situations.
 - name: Enable lingering for Elastic user
   ansible.builtin.shell: loginctl enable-linger elastic

--- a/tasks/base/general/configure_podman_ipv6_network.yml
+++ b/tasks/base/general/configure_podman_ipv6_network.yml
@@ -1,0 +1,34 @@
+---
+# Optional dual-stack default network for Podman hosts that need IPv6.
+# Off by default. When ece_podman_ipv6_network is true the role creates
+# ece_podman_network_name with both an IPv4 and IPv6 subnet and makes it
+# Podman's default so ECE containers get an IPv6 address.
+- name: Check whether the Podman IPv6 network already exists
+  command: podman network exists {{ ece_podman_network_name }}
+  register: ece_podman_network_exists
+  changed_when: false
+  failed_when: false
+
+- name: Create a dual-stack Podman network
+  command: >
+    podman network create
+    --subnet {{ ece_podman_network_ipv4_subnet }}
+    --subnet {{ ece_podman_network_ipv6_subnet }}
+    --ipv6
+    {{ ece_podman_network_name }}
+  when: ece_podman_network_exists.rc != 0
+
+- name: Ensure /etc/containers/containers.conf exists
+  copy:
+    src: /usr/share/containers/containers.conf
+    dest: /etc/containers/containers.conf
+    remote_src: true
+    force: false
+
+- name: Use the dual-stack network as Podman's default
+  ini_file:
+    path: /etc/containers/containers.conf
+    section: network
+    option: default_network
+    value: '"{{ ece_podman_network_name }}"'
+    no_extra_spaces: true

--- a/tasks/base/general/configure_podman_ipv6_network.yml
+++ b/tasks/base/general/configure_podman_ipv6_network.yml
@@ -31,3 +31,10 @@
     option: default_network
     value: '"{{ ece_podman_network_name }}"'
     no_extra_spaces: true
+
+# Official RHEL host-prep restarts Podman after setting default_network.
+- name: Restart Podman so the dual-stack default network applies
+  systemd:
+    name: podman
+    state: restarted
+    daemon_reload: true

--- a/tasks/base/general/configure_podman_ipv6_network.yml
+++ b/tasks/base/general/configure_podman_ipv6_network.yml
@@ -1,8 +1,7 @@
 ---
-# Optional dual-stack default network for Podman hosts that need IPv6.
-# Off by default. When ece_podman_ipv6_network is true the role creates
-# ece_podman_network_name with both an IPv4 and IPv6 subnet and makes it
-# Podman's default so ECE containers get an IPv6 address.
+# Optional dual-stack default network for Podman hosts that need IPv6. Off by default. When
+# ece_podman_ipv6_network is true the role creates ece_podman_network_name with both an IPv4 and
+# IPv6 subnet and makes it Podman's default so ECE containers get an IPv6 address.
 - name: Check whether the Podman IPv6 network already exists
   command: podman network exists {{ ece_podman_network_name }}
   register: ece_podman_network_exists

--- a/tasks/base/general/hold_docker_ce.yml
+++ b/tasks/base/general/hold_docker_ce.yml
@@ -1,0 +1,9 @@
+# Official Ubuntu host-prep pins the packages this role actually installs.
+- name: Hold installed Docker packages
+  dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io

--- a/tasks/base/general/make_user.yml
+++ b/tasks/base/general/make_user.yml
@@ -23,16 +23,21 @@
     cacheable: true
   when: ansible_user == "elastic"
 
+# Matches the official host-prep docs: `groupadd elastic` / `groupadd docker|podman`
+# then `useradd -g elastic -G docker|podman elastic` (no pinned uid/gid) and
+# `elastic ALL=(ALL) NOPASSWD:ALL` in /etc/sudoers.d/99-ece-users.
+# Only pin uid/gid when the caller sets elastic_uid / elastic_gid (or when
+# ansible_user is already `elastic`, so we adopt that account).
 - name: Add group elastic
   group:
-    name:  elastic
+    name: elastic
     state: present
-    gid: "{{ elastic_gid | default(1234) }}"
+    gid: "{{ elastic_gid | default(omit) }}"
   when: "'elastic' not in ansible_facts.getent_group"
 
 - name: Add group {{ container_engine }}
   group:
-    name:  "{{ container_engine | lower }}"
+    name: "{{ container_engine | lower }}"
     state: present
   when: container_engine | lower not in ansible_facts.getent_group
 
@@ -41,7 +46,7 @@
     name: elastic
     group: elastic
     groups: "{{ container_engine | lower }}"
-    uid: "{{ elastic_uid | default(1234) }}"
+    uid: "{{ elastic_uid | default(omit) }}"
     append: yes
     state: present
     generate_ssh_key: true

--- a/tasks/base/general/make_user.yml
+++ b/tasks/base/general/make_user.yml
@@ -23,11 +23,10 @@
     cacheable: true
   when: ansible_user == "elastic"
 
-# Matches the official host-prep docs: `groupadd elastic` / `groupadd docker|podman`
-# then `useradd -g elastic -G docker|podman elastic` (no pinned uid/gid) and
-# `elastic ALL=(ALL) NOPASSWD:ALL` in /etc/sudoers.d/99-ece-users.
-# Only pin uid/gid when the caller sets elastic_uid / elastic_gid (or when
-# ansible_user is already `elastic`, so we adopt that account).
+# Matches the official host-prep docs: `groupadd elastic` / `groupadd docker|podman` then
+# `useradd -g elastic -G docker|podman elastic` (no pinned uid/gid) and
+# `elastic ALL=(ALL) NOPASSWD:ALL` in /etc/sudoers.d/99-ece-users. Only pin uid/gid when the caller
+# sets elastic_uid / elastic_gid (or when ansible_user is already `elastic`, so we adopt that account).
 - name: Add group elastic
   group:
     name: elastic

--- a/tasks/base/general/set_limits.yml
+++ b/tasks/base/general/set_limits.yml
@@ -28,3 +28,22 @@
   file:
     path: /etc/security/limits.d/20-nproc.conf
     state: absent
+
+# systemd 252+ (RHEL 9, Ubuntu 24) compiles in DefaultLimitNOFILE=1024, which
+# overrides limits.conf for SSH sessions and systemd-managed services. ECE's
+# preflight check requires nofile >= 65536. A drop-in raises the default for
+# every service, including docker/podman and ssh@.service.
+- name: Ensure systemd system.conf.d exists
+  file:
+    path: /etc/systemd/system.conf.d
+    state: directory
+    mode: "0755"
+
+- name: Raise systemd DefaultLimitNOFILE for ECE
+  copy:
+    dest: /etc/systemd/system.conf.d/99-elastic-nofile.conf
+    mode: "0644"
+    content: |
+      [Manager]
+      DefaultLimitNOFILE=1024000
+

--- a/tasks/base/general/set_limits.yml
+++ b/tasks/base/general/set_limits.yml
@@ -20,6 +20,8 @@
   - { domain: 'elastic', limit_type: 'hard', limit_item: 'nofile', value: '1024000' }
   - { domain: 'elastic', limit_type: 'soft', limit_item: 'memlock', value: 'unlimited' }
   - { domain: 'elastic', limit_type: 'hard', limit_item: 'memlock', value: 'unlimited' }
+  - { domain: 'elastic', limit_type: 'soft', limit_item: 'nproc', value: 'unlimited' }
+  - { domain: 'elastic', limit_type: 'hard', limit_item: 'nproc', value: 'unlimited' }
   - { domain: 'root', limit_type: 'soft', limit_item: 'nofile', value: '1024000' }
   - { domain: 'root', limit_type: 'hard', limit_item: 'nofile', value: '1024000' }
   - { domain: 'root', limit_type: 'soft', limit_item: 'memlock', value: 'unlimited' }
@@ -45,4 +47,12 @@
     content: |
       [Manager]
       DefaultLimitNOFILE=1024000
+  register: ece_systemd_nofile
+
+# Drop-in is ignored by the current PID 1 until reexec. Docker/Podman start later
+# in this role, so they inherit the new default after this.
+- name: Reload systemd so DefaultLimitNOFILE applies to later services
+  systemd:
+    daemon_reexec: true
+  when: ece_systemd_nofile is changed
 

--- a/tasks/base/general/set_limits.yml
+++ b/tasks/base/general/set_limits.yml
@@ -29,10 +29,9 @@
     path: /etc/security/limits.d/20-nproc.conf
     state: absent
 
-# systemd 252+ (RHEL 9, Ubuntu 24) compiles in DefaultLimitNOFILE=1024, which
-# overrides limits.conf for SSH sessions and systemd-managed services. ECE's
-# preflight check requires nofile >= 65536. A drop-in raises the default for
-# every service, including docker/podman and ssh@.service.
+# systemd 252+ (RHEL 9, Ubuntu 24) compiles in DefaultLimitNOFILE=1024, which overrides limits.conf
+# for SSH sessions and systemd-managed services. ECE's preflight check requires nofile >= 65536. A
+# drop-in raises the default for every service, including docker/podman and ssh@.service.
 - name: Ensure systemd system.conf.d exists
   file:
     path: /etc/systemd/system.conf.d

--- a/tasks/base/general/sysctl_scripts.yml
+++ b/tasks/base/general/sysctl_scripts.yml
@@ -9,21 +9,35 @@
     path: "{{ sysctl_settings_file }}"
     state: touch
 
+# Kernel values from the Ubuntu / RHEL / SLES ECE host-prep guides. IPv6
+# forwarding is only added when a dual-stack container network was requested.
+- name: Build ECE sysctl list
+  set_fact:
+    ece_sysctl_items: "{{ ece_sysctl_base + ece_sysctl_ipv6 }}"
+  vars:
+    ece_sysctl_base:
+      - { name: 'net.ipv4.tcp_max_syn_backlog', value: '65536' }
+      - { name: 'net.core.somaxconn', value: '32768' }
+      - { name: 'net.core.netdev_max_backlog', value: '32768' }
+      - { name: 'vm.max_map_count', value: '1048576' }
+      - { name: 'vm.swappiness', value: '1' }
+      - { name: 'net.ipv4.tcp_keepalive_time', value: '1800' }
+      - { name: 'net.ipv4.tcp_retries2', value: '5' }
+      - { name: 'net.netfilter.nf_conntrack_tcp_timeout_established', value: '7200' }
+      - { name: 'net.netfilter.nf_conntrack_max', value: '262140' }
+      - { name: 'net.ipv4.ip_forward', value: '1' }
+    ece_sysctl_ipv6: >-
+      {{ [{'name': 'net.ipv6.conf.all.forwarding', 'value': '1'}]
+         if (ece_podman_ipv6_network | default(false) | bool
+             or ece_docker_ipv6 | default(false) | bool)
+         else [] }}
+
 - name: sysctl_scripts.yml || set sysctl items
   sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     reload: yes
     state: present
-    sysctl_set: yes 
+    sysctl_set: yes
     sysctl_file: "{{ sysctl_settings_file }}"
-  with_items:
-  -  { name: 'net.ipv4.tcp_max_syn_backlog', value: '65536' }
-  -  { name: 'net.core.somaxconn', value: '32768' }
-  -  { name: 'net.core.netdev_max_backlog', value: '32768' }
-  -  { name: 'vm.max_map_count', value: '262144' }
-  -  { name: 'vm.swappiness', value: '1' }
-  -  { name: 'net.ipv4.tcp_keepalive_time', value: '1800' }
-  -  { name: 'net.netfilter.nf_conntrack_tcp_timeout_established', value: '7200' }
-  -  { name: 'net.netfilter.nf_conntrack_max', value: '262140' }
-  -  { name: 'net.ipv4.ip_forward', value: '1'}
+  with_items: "{{ ece_sysctl_items }}"

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -18,6 +18,27 @@
       ece_os_experimental=true.
   when: ece_os_experimental | default(false) | bool
 
+# RHEL 8/9 ship both Docker and Podman maps. Pick the engine from the version
+# extra-var the caller actually set. Empty strings (CI passing docker_version=
+# or podman_version=) are ignored. A docker_version that starts with "podman"
+# is a CI env label (e.g. podman-default-4), not a Docker release.
+# If both a real podman_version and a real docker_version are set, Podman wins.
+- name: Select Podman when a version is requested and this OS supports it
+  set_fact:
+    container_engine: Podman
+  when:
+    - podman_version | default('') | string | length > 0
+    - podman_version_map is defined
+
+- name: Select Docker when a version is requested and this OS supports it
+  set_fact:
+    container_engine: Docker
+  when:
+    - docker_version | default('') | string | length > 0
+    - docker_version is not match('^podman')
+    - docker_version_map is defined
+    - not (podman_version | default('') | string | length > 0 and podman_version_map is defined)
+
 # default(..., true) so an empty string (e.g. docker_version= passed through from
 # an unset CI variable) also falls back to the map default, not just an undefined
 # value.
@@ -70,6 +91,11 @@
 - include_tasks: general/configure_podman.yml
   tags: [install_podman, install_docker, destructive]
   when: container_engine == "Podman"
+- include_tasks: general/configure_podman_ipv6_network.yml
+  tags: [install_podman, install_docker, destructive]
+  when:
+    - container_engine == "Podman"
+    - ece_podman_ipv6_network | default(false) | bool
 - include_tasks: general/sysctl_scripts.yml
 - include_tasks: general/kernel_modules.yml
 

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -38,6 +38,14 @@
     - docker_version_map is defined
     - not (podman_version | default('') | string | length > 0 and podman_version_map is defined)
 
+- name: Warn when this OS and container engine combination is experimental
+  debug:
+    msg: >-
+      WARNING: {{ ansible_distribution }} {{ ansible_distribution_major_version }} with
+      {{ container_engine }} is EXPERIMENTAL in this role and is not an official ECE
+      support-matrix combination. Proceeding anyway.
+  when: container_engine in (ece_experimental_container_engines | default([]))
+
 # default(..., true) so an empty string (e.g. docker_version= passed through from
 # an unset CI variable) also falls back to the map default, not just an undefined
 # value.

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -18,11 +18,10 @@
       ece_os_experimental=true.
   when: ece_os_experimental | default(false) | bool
 
-# RHEL 8/9 ship both Docker and Podman maps. Pick the engine from the version
-# extra-var the caller actually set. Empty strings (CI passing docker_version=
-# or podman_version=) are ignored. A docker_version that starts with "podman"
-# is a CI env label (e.g. podman-default-4), not a Docker release.
-# If both a real podman_version and a real docker_version are set, Podman wins.
+# RHEL 8/9 ship both Docker and Podman maps. Pick the engine from the version extra-var the caller
+# actually set. Empty strings (CI passing docker_version= or podman_version=) are ignored. A
+# docker_version that starts with "podman" is a CI env label (e.g. podman-default-4), not a Docker
+# release. If both a real podman_version and a real docker_version are set, Podman wins.
 - name: Select Podman when a version is requested and this OS supports it
   set_fact:
     container_engine: Podman

--- a/templates/docker.conf
+++ b/templates/docker.conf
@@ -4,7 +4,7 @@ After={{ docker_unit_after }}
 
 [Service]
 EnvironmentFile=
-Environment="DOCKER_OPTS=-H unix:///var/run/docker.sock --data-root {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --icc=false --default-ulimit nofile={{ docker_default_nofile }}:{{ docker_default_nofile }}"
+Environment="DOCKER_OPTS=-H unix:///var/run/docker.sock --data-root {{ data_dir }}/docker --storage-driver={{ docker_storage_driver }} --bip={{ docker_bridge_ip }} --raw-logs --log-opt max-size=500m --log-opt max-file=10 --icc=false --default-ulimit nofile={{ docker_default_nofile }}:{{ docker_default_nofile }} --default-ulimit memlock=-1:-1 --default-ulimit nproc=-1:-1"
 ExecStart=
 ExecStart=/usr/bin/dockerd $DOCKER_OPTS
 Restart=on-failure

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -3,6 +3,8 @@ docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
 bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
+# Default stays Docker so existing RHEL 8 Docker installs keep working.
+# Set podman_version (and leave docker_version empty / podman-*) to use Podman.
 container_engine: Docker
 
 # Docker version mapping
@@ -27,3 +29,12 @@ docker_version_map:
     keys:
       server: https://download.docker.com/linux/centos/gpg
       id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35
+
+# Podman version mapping. Same major-glob pattern as RHEL 9: "4" installs the
+# latest available 4.x from the RHEL 8 repos.
+podman_version_map:
+  "4":
+    name: "podman"
+    package:
+      - podman-4.*
+      - podman-remote-4.*

--- a/vars/os_RedHat_8.yml
+++ b/vars/os_RedHat_8.yml
@@ -3,8 +3,8 @@ docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
 bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
-# Default stays Docker so existing RHEL 8 Docker installs keep working.
-# Set podman_version (and leave docker_version empty / podman-*) to use Podman.
+# Default stays Docker so existing RHEL 8 Docker installs keep working. Set podman_version (and
+# leave docker_version empty / podman-*) to use Podman.
 container_engine: Docker
 
 # Docker version mapping
@@ -30,8 +30,8 @@ docker_version_map:
       server: https://download.docker.com/linux/centos/gpg
       id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35
 
-# Podman version mapping. Same major-glob pattern as RHEL 9: "4" installs the
-# latest available 4.x from the RHEL 8 repos.
+# Podman version mapping. Same major-glob pattern as RHEL 9: "4" installs the latest available 4.x
+# from the RHEL 8 repos.
 podman_version_map:
   "4":
     name: "podman"

--- a/vars/os_RedHat_9.yml
+++ b/vars/os_RedHat_9.yml
@@ -1,7 +1,25 @@
 ---
 bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
+docker_unit_after: "multi-user.target"
+docker_storage_driver: overlay2
+# Default stays Podman (the supported RHEL 9 ECE path). Set docker_version to a
+# Docker release (e.g. 29.0) to install Docker CE instead.
 container_engine: Podman
+
+# Docker version mapping. "29.0" is the ECE matrix label for Docker 29.x;
+# the dnf glob is 29* so a later 29.x patch is installed.
+docker_version_map:
+  "29.0":
+    name: 'Docker-CE'
+    package:
+      - docker-ce-29*
+      - docker-ce-cli-29*
+      - containerd.io
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    keys:
+      server: https://download.docker.com/linux/centos/gpg
+      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35
 
 # Podman version mapping. Package specs are dnf globs so the latest available
 # patch release for the chosen major is installed (matching the ECE docs

--- a/vars/os_RedHat_9.yml
+++ b/vars/os_RedHat_9.yml
@@ -3,12 +3,12 @@ bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
-# Default stays Podman (the supported RHEL 9 ECE path). Set docker_version to a
-# Docker release (e.g. 29.0) to install Docker CE instead.
+# Default stays Podman (the supported RHEL 9 ECE path). Set docker_version to a Docker release
+# (e.g. 29.0) to install Docker CE instead.
 container_engine: Podman
 
-# Docker version mapping. "29.0" is the ECE matrix label for Docker 29.x;
-# the dnf glob is 29* so a later 29.x patch is installed.
+# Docker version mapping. "29.0" is the ECE matrix label for Docker 29.x; the dnf glob is 29* so a
+# later 29.x patch is installed.
 docker_version_map:
   "29.0":
     name: 'Docker-CE'

--- a/vars/os_RedHat_9.yml
+++ b/vars/os_RedHat_9.yml
@@ -3,12 +3,18 @@ bootloader_update_command: grub2-mkconfig -o /etc/grub2.cfg
 conntrack_module: ip_conntrack
 docker_unit_after: "multi-user.target"
 docker_storage_driver: overlay2
-# Default stays Podman (the supported RHEL 9 ECE path). Set docker_version to a Docker release
-# (e.g. 29.0) to install Docker CE instead.
+# Default stays Podman (the official ECE support-matrix path for RHEL 9). Docker CE is installable
+# for CI/BC coverage but is not a documented/supported combination — see
+# ece_experimental_container_engines.
 container_engine: Podman
 
+# Docker on RHEL 9 is not in the official ECE support matrix (host-prep docs are Podman-only).
+# Same idea as ece_os_experimental on RHEL 10: the role can install it, but it warns.
+ece_experimental_container_engines:
+  - Docker
+
 # Docker version mapping. "29.0" is the ECE matrix label for Docker 29.x; the dnf glob is 29* so a
-# later 29.x patch is installed.
+# later 29.x patch is installed. Experimental — not a support-matrix combination.
 docker_version_map:
   "29.0":
     name: 'Docker-CE'

--- a/vars/os_SLES_15.yml
+++ b/vars/os_SLES_15.yml
@@ -5,7 +5,20 @@ bootloader_update_command: update-bootloader
 conntrack_module: ip_conntrack
 container_engine: Docker
 
-# Docker version mapping
+# Docker version mapping. SLES 15 zypper only ships an old docker-ce package
+# (20.10). Docker 25+ is installed from the official static tarball because
+# there is no matching zypper package. The last key is the default when no
+# docker_version is requested.
+#
+# Static tarball_version must be an exact Docker release (wildcards do not
+# work on download.docker.com/linux/static).
 docker_version_map:
   "20.10":
+    method: zypper
     package: docker-20.10.12_ce
+  "25.0":
+    method: static
+    tarball_version: "25.0.5"
+  "29.0":
+    method: static
+    tarball_version: "29.7.2"

--- a/vars/os_SLES_15.yml
+++ b/vars/os_SLES_15.yml
@@ -5,13 +5,12 @@ bootloader_update_command: update-bootloader
 conntrack_module: ip_conntrack
 container_engine: Docker
 
-# Docker version mapping. SLES 15 zypper only ships an old docker-ce package
-# (20.10). Docker 25+ is installed from the official static tarball because
-# there is no matching zypper package. The last key is the default when no
-# docker_version is requested.
+# Docker version mapping. SLES 15 zypper only ships an old docker-ce package (20.10). Docker 25+ is
+# installed from the official static tarball because there is no matching zypper package. The last
+# key is the default when no docker_version is requested.
 #
-# Static tarball_version must be an exact Docker release (wildcards do not
-# work on download.docker.com/linux/static).
+# Static tarball_version must be an exact Docker release (wildcards do not work on
+# download.docker.com/linux/static).
 docker_version_map:
   "20.10":
     method: zypper

--- a/vars/os_Ubuntu_20.yml
+++ b/vars/os_Ubuntu_20.yml
@@ -5,12 +5,23 @@ bootloader_update_command: update-grub
 conntrack_module: xt_conntrack
 container_engine: Docker
 
-# Docker version mapping
+# Docker version mapping. The last key is the default when no docker_version
+# is requested. "27.0" is the ECE matrix label for Docker 27.x (27.5.1 today);
+# the apt glob is 27.* so a later 27.x patch is installed.
 docker_version_map:
   "20.10":
     package:
       - docker-ce=5:20.10.14*
       - docker-ce-cli=5:20.10.14*
+      - containerd.io
+    repo: deb https://download.docker.com/linux/ubuntu focal stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      id: 0EBFCD88
+  "27.0":
+    package:
+      - docker-ce=5:27.*
+      - docker-ce-cli=5:27.*
       - containerd.io
     repo: deb https://download.docker.com/linux/ubuntu focal stable
     keys:

--- a/vars/os_Ubuntu_20.yml
+++ b/vars/os_Ubuntu_20.yml
@@ -5,9 +5,9 @@ bootloader_update_command: update-grub
 conntrack_module: xt_conntrack
 container_engine: Docker
 
-# Docker version mapping. The last key is the default when no docker_version
-# is requested. "27.0" is the ECE matrix label for Docker 27.x (27.5.1 today);
-# the apt glob is 27.* so a later 27.x patch is installed.
+# Docker version mapping. The last key is the default when no docker_version is requested. "27.0"
+# is the ECE matrix label for Docker 27.x (27.5.1 today); the apt glob is 27.* so a later 27.x
+# patch is installed.
 docker_version_map:
   "20.10":
     package:

--- a/vars/os_Ubuntu_24.yml
+++ b/vars/os_Ubuntu_24.yml
@@ -1,0 +1,21 @@
+---
+docker_unit_after: "multi-user.target"
+docker_storage_driver: overlay2
+bootloader_update_command: update-grub
+conntrack_module: xt_conntrack
+container_engine: Docker
+
+# Docker version mapping. Ubuntu 24.04 is "noble". "29.0" is the ECE matrix
+# label for Docker 29.x (29.7 today); the apt glob is 29.* so a later 29.x
+# patch is installed. The last key is the default when no docker_version is
+# requested.
+docker_version_map:
+  "29.0":
+    package:
+      - docker-ce=5:29.*
+      - docker-ce-cli=5:29.*
+      - containerd.io
+    repo: deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      dest: /etc/apt/keyrings/docker.asc

--- a/vars/os_Ubuntu_24.yml
+++ b/vars/os_Ubuntu_24.yml
@@ -5,10 +5,9 @@ bootloader_update_command: update-grub
 conntrack_module: xt_conntrack
 container_engine: Docker
 
-# Docker version mapping. Ubuntu 24.04 is "noble". "29.0" is the ECE matrix
-# label for Docker 29.x (29.7 today); the apt glob is 29.* so a later 29.x
-# patch is installed. The last key is the default when no docker_version is
-# requested.
+# Docker version mapping. Ubuntu 24.04 is "noble". "29.0" is the ECE matrix label for Docker 29.x
+# (29.7 today); the apt glob is 29.* so a later 29.x patch is installed. The last key is the
+# default when no docker_version is requested.
 docker_version_map:
   "29.0":
     package:


### PR DESCRIPTION
## Summary
- Add Ubuntu 24.04 Docker 29.x (noble, apt keyring install). Ubuntu 24 is cgroup v2; this path does not require cgroup v1.
- Add Ubuntu 20.04 Docker 27.x (`27.*` apt glob; "27.0" is the ECE matrix label).
- Add SLES 15 Docker 25.0.5 and 29.7.2 from the official static tarball. Zypper 20.10 remains available.
- Add RHEL 8 Podman 4 (CNI). Existing RHEL 8 Docker 19.03/20.10 stays the default.
- Add RHEL 9 Docker 29.x as **experimental** (not an official support-matrix combo; host-prep docs are Podman-only). Podman stays the default. Selecting Docker emits the same class of runtime warning as RHEL 10 (`ece_experimental_container_engines`).
- Dual-engine OSes select Podman or Docker from the version extra-vars. A `docker_version` that starts with `podman` is treated as a CI label, not a Docker release. If both real versions are set, Podman wins.
- Optional `ece_podman_ipv6_network` creates a dual-stack default network (`ece-network`) before ECE install.
- Raise systemd `DefaultLimitNOFILE` so ECE preflight passes on systemd 252+ (RHEL 9, Ubuntu 24).
- Create `elastic` the way the published host-prep docs do (`groupadd` / `useradd` with no pinned uid/gid). Callers can still set `elastic_uid` / `elastic_gid`. The ce-aws uid-1000 alias stays in [elastic/cloud#158721](https://github.com/elastic/cloud/pull/158721), not this role.

No ce-aws names, MinIO, or test-harness port lists in this role.

## Test plan
Exercised via [elastic/cloud#158721](https://github.com/elastic/cloud/pull/158721) foundations ITs (`ANSIBLE_ECE_BRANCH=feat/remaining-os-runtimes`):

- [x] Ubuntu 24.04 / Docker 29
- [x] Ubuntu 20.04 / Docker 27
- [x] SLES 15 / Docker 25 and 29
- [x] RHEL 8 / Podman 4 (stock, IPv6, SELinux)
- [x] RHEL 9 / Docker 29 (experimental path)
- [ ] Existing RHEL 9 Podman and Ubuntu 22 Docker paths were not re-run in this PR (already covered by earlier role merges)

<small>*(AI-authored via Cursor 🤖)*</small>