### PR TITLE
Treat bare docker_version majors as latest; do not pin Docker 29.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ docker_unit_after: "network.target docker.socket"
 docker_storage_driver: overlay
 bootloader_update_command: update-bootloader
 
-# Docker version mapping
+# Docker version mapping.
+# "N" is latest of that major; "N.M" is that minor line only.
 docker_version_map:
   "19.03":
     package: docker-19.03.14_ce

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following variables are avaible:
     - Default: `/home/elastic/.docker`
     - Override only if you install ECE as a user other than `elastic`. The container-side mount target is always `/home/elastic/.docker` (the `elastic` user's home inside the ECE images).
 - [Supported Docker Versions](https://www.elastic.co/guide/en/cloud-enterprise/2.7/ece-software-prereq.html#ece-linux-docker)
-  - `docker_version`: Last supported version on Centos 7/8 and RHEL 7/8 is 20.0, Ubuntu 16, Ubuntu 18 and SLES 12 is 19.03.
+  - `docker_version`: Must be a key in the OS `docker_version_map` (or a bare major that resolves to one). A bare major (`24`, `29`) installs the latest mapped line of that major; `24.0` / `29.0` install that minor line only. Last supported version on Centos 7/8 and RHEL 7/8 is 20.0, Ubuntu 16, Ubuntu 18 and SLES 12 is 19.03.
 - `docker_bridge_ip `: The default IP of the docker bridge. Configurable to avoid overlapping with the current host subnet.
 - `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
     - Default: false

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following variables are avaible:
     - Default: `/home/elastic/.docker`
     - Override only if you install ECE as a user other than `elastic`. The container-side mount target is always `/home/elastic/.docker` (the `elastic` user's home inside the ECE images).
 - [Supported Docker Versions](https://www.elastic.co/guide/en/cloud-enterprise/2.7/ece-software-prereq.html#ece-linux-docker)
-  - `docker_version`: Must be a key in the OS `docker_version_map` (or a bare major that resolves to one). A bare major (`24`, `29`) installs the latest mapped line of that major; `24.0` / `29.0` install that minor line only. Last supported version on Centos 7/8 and RHEL 7/8 is 20.0, Ubuntu 16, Ubuntu 18 and SLES 12 is 19.03.
+  - `docker_version`: Must be a key in the OS `docker_version_map` (or a bare major that resolves to one). A bare major (`24`, `29`) installs the latest mapped line of that major; `24.0` / `25.0` install that minor line only when the OS ships it. There is no `29.0` pin — ECE needs Docker 29.3+. Last supported version on Centos 7/8 and RHEL 7/8 is 20.0, Ubuntu 16, Ubuntu 18 and SLES 12 is 19.03.
 - `docker_bridge_ip `: The default IP of the docker bridge. Configurable to avoid overlapping with the current host subnet.
 - `force_xfc`: By default if the `lxc` xfc volume already exists, the `setup_xfc` step is skipped, if this is set to true, creation of the volume is forced
     - Default: false

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -49,10 +49,25 @@
 # default(..., true) so an empty string (e.g. docker_version= passed through from
 # an unset CI variable) also falls back to the map default, not just an undefined
 # value.
+#
+# Version contract:
+#   "24"   — latest mapped line of that major (24.latest)
+#   "24.0" — exact map key (that minor line only)
+# If the caller passed a bare major and that key is not in the map, resolve to the
+# last key that starts with "{major}." (YAML insertion order). "24.0" is never
+# rewritten.
 - name: Set Docker version
   set_fact:
     docker_version: "{{ docker_version | default(docker_version_map.keys()|list|last, true) }}"
   when: container_engine == "Docker"
+
+- name: Resolve bare Docker major to latest mapped line
+  set_fact:
+    docker_version: "{{ (docker_version_map.keys() | select('match', '^' + docker_version + '(\\..+)?$') | list | last) | default(docker_version, true) }}"
+  when:
+    - container_engine == "Docker"
+    - docker_version is match('^[0-9]+$')
+    - docker_version not in docker_version_map
 
 - name: Set Podman version
   set_fact:

--- a/tasks/base/main.yml
+++ b/tasks/base/main.yml
@@ -58,12 +58,13 @@
 # rewritten.
 - name: Set Docker version
   set_fact:
-    docker_version: "{{ docker_version | default(docker_version_map.keys()|list|last, true) }}"
+    # |string so extra-vars like -e docker_version=29 (YAML int) match string map keys.
+    docker_version: "{{ docker_version | default(docker_version_map.keys()|list|last, true) | string }}"
   when: container_engine == "Docker"
 
 - name: Resolve bare Docker major to latest mapped line
   set_fact:
-    docker_version: "{{ (docker_version_map.keys() | select('match', '^' + docker_version + '(\\..+)?$') | list | last) | default(docker_version, true) }}"
+    docker_version: "{{ (docker_version_map.keys() | select('match', '^' ~ docker_version ~ '(\\..+)?$') | list | last) | default(docker_version, true) }}"
   when:
     - container_engine == "Docker"
     - docker_version is match('^[0-9]+$')

--- a/vars/os_RedHat_9.yml
+++ b/vars/os_RedHat_9.yml
@@ -14,19 +14,8 @@ ece_experimental_container_engines:
   - Docker
 
 # Docker version mapping. Experimental — not a support-matrix combination.
-#   "29"   — latest 29.x (dnf glob 29*)
-#   "29.0" — 29.0.x only (dnf glob 29.0*)
+#   "29" — latest 29.x (dnf glob 29*). ECE needs Docker 29.3+; no 29.0 pin.
 docker_version_map:
-  "29.0":
-    name: 'Docker-CE'
-    package:
-      - docker-ce-29.0*
-      - docker-ce-cli-29.0*
-      - containerd.io
-    repo: https://download.docker.com/linux/centos/docker-ce.repo
-    keys:
-      server: https://download.docker.com/linux/centos/gpg
-      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35
   "29":
     name: 'Docker-CE'
     package:

--- a/vars/os_RedHat_9.yml
+++ b/vars/os_RedHat_9.yml
@@ -13,10 +13,21 @@ container_engine: Podman
 ece_experimental_container_engines:
   - Docker
 
-# Docker version mapping. "29.0" is the ECE matrix label for Docker 29.x; the dnf glob is 29* so a
-# later 29.x patch is installed. Experimental — not a support-matrix combination.
+# Docker version mapping. Experimental — not a support-matrix combination.
+#   "29"   — latest 29.x (dnf glob 29*)
+#   "29.0" — 29.0.x only (dnf glob 29.0*)
 docker_version_map:
   "29.0":
+    name: 'Docker-CE'
+    package:
+      - docker-ce-29.0*
+      - docker-ce-cli-29.0*
+      - containerd.io
+    repo: https://download.docker.com/linux/centos/docker-ce.repo
+    keys:
+      server: https://download.docker.com/linux/centos/gpg
+      id: 060A 61C5 1B55 8A7F 742B 77AA C52F EB6B 621E 9F35
+  "29":
     name: 'Docker-CE'
     package:
       - docker-ce-29*

--- a/vars/os_SLES_15.yml
+++ b/vars/os_SLES_15.yml
@@ -7,8 +7,9 @@ container_engine: Docker
 
 # Docker version mapping. SLES 15 zypper only ships an old docker-ce package (20.10). Docker 25+ is
 # installed from the official static tarball because there is no matching zypper package.
-#   "25" / "29"     — latest static pin we ship for that major
-#   "25.0" / "29.0" — that minor line (static has no wildcard; pin the last 25.0 / 29.0 patch)
+#   "25" / "29" — latest static pin we ship for that major
+#   "25.0"      — Docker 25.0.x (only 25 line; same tarball as "25")
+# There is no "29.0" pin: ECE needs Docker 29.3+.
 # The last key is the default when no docker_version is requested.
 #
 # Static tarball_version must be an exact Docker release (wildcards do not work on
@@ -23,9 +24,6 @@ docker_version_map:
   "25":
     method: static
     tarball_version: "25.0.5"
-  "29.0":
-    method: static
-    tarball_version: "29.0.4"
   "29":
     method: static
     tarball_version: "29.7.2"

--- a/vars/os_SLES_15.yml
+++ b/vars/os_SLES_15.yml
@@ -6,8 +6,10 @@ conntrack_module: ip_conntrack
 container_engine: Docker
 
 # Docker version mapping. SLES 15 zypper only ships an old docker-ce package (20.10). Docker 25+ is
-# installed from the official static tarball because there is no matching zypper package. The last
-# key is the default when no docker_version is requested.
+# installed from the official static tarball because there is no matching zypper package.
+#   "25" / "29"     — latest static pin we ship for that major
+#   "25.0" / "29.0" — that minor line (static has no wildcard; pin the last 25.0 / 29.0 patch)
+# The last key is the default when no docker_version is requested.
 #
 # Static tarball_version must be an exact Docker release (wildcards do not work on
 # download.docker.com/linux/static).
@@ -18,6 +20,12 @@ docker_version_map:
   "25.0":
     method: static
     tarball_version: "25.0.5"
+  "25":
+    method: static
+    tarball_version: "25.0.5"
   "29.0":
+    method: static
+    tarball_version: "29.0.4"
+  "29":
     method: static
     tarball_version: "29.7.2"

--- a/vars/os_Ubuntu_22.yml
+++ b/vars/os_Ubuntu_22.yml
@@ -5,10 +5,11 @@ bootloader_update_command: update-grub
 conntrack_module: xt_conntrack
 container_engine: Docker
 
-# Docker version mapping. Ubuntu 22.04 is "jammy" (the repo previously pointed at
-# "focal"/20.04). Package specs pin the major via apt globs so the latest patch
-# release is installed. The last key is the default when no docker_version is
-# requested.
+# Docker version mapping. Ubuntu 22.04 is "jammy".
+#   "24" / "25"   — latest patch of that major (apt glob N.*)
+#   "24.0" / "25.0" — that minor line only (apt glob N.0.*)
+# Docker 24 and 25 only shipped a .0 line, so the two globs resolve the same
+# today. The last key is the default when no docker_version is requested.
 docker_version_map:
   "24.0":
     package:
@@ -19,10 +20,28 @@ docker_version_map:
     keys:
       server: https://download.docker.com/linux/ubuntu/gpg
       id: 0EBFCD88
+  "24":
+    package:
+      - docker-ce=5:24.*
+      - docker-ce-cli=5:24.*
+      - containerd.io
+    repo: deb https://download.docker.com/linux/ubuntu jammy stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      id: 0EBFCD88
   "25.0":
     package:
       - docker-ce=5:25.0.*
       - docker-ce-cli=5:25.0.*
+      - containerd.io
+    repo: deb https://download.docker.com/linux/ubuntu jammy stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      id: 0EBFCD88
+  "25":
+    package:
+      - docker-ce=5:25.*
+      - docker-ce-cli=5:25.*
       - containerd.io
     repo: deb https://download.docker.com/linux/ubuntu jammy stable
     keys:

--- a/vars/os_Ubuntu_24.yml
+++ b/vars/os_Ubuntu_24.yml
@@ -6,19 +6,10 @@ conntrack_module: xt_conntrack
 container_engine: Docker
 
 # Docker version mapping. Ubuntu 24.04 is "noble".
-#   "29"   — latest 29.x (apt glob 29.*)
-#   "29.0" — 29.0.x only (apt glob 29.0.*)
+#   "29" — latest 29.x (apt glob 29.*). ECE needs Docker 29.3+; there is no
+#   29.0 pin (29.0–29.2 are not an ECE-supported runtime).
 # The last key is the default when no docker_version is requested.
 docker_version_map:
-  "29.0":
-    package:
-      - docker-ce=5:29.0.*
-      - docker-ce-cli=5:29.0.*
-      - containerd.io
-    repo: deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable
-    keys:
-      server: https://download.docker.com/linux/ubuntu/gpg
-      dest: /etc/apt/keyrings/docker.asc
   "29":
     package:
       - docker-ce=5:29.*

--- a/vars/os_Ubuntu_24.yml
+++ b/vars/os_Ubuntu_24.yml
@@ -5,11 +5,21 @@ bootloader_update_command: update-grub
 conntrack_module: xt_conntrack
 container_engine: Docker
 
-# Docker version mapping. Ubuntu 24.04 is "noble". "29.0" is the ECE matrix label for Docker 29.x
-# (29.7 today); the apt glob is 29.* so a later 29.x patch is installed. The last key is the
-# default when no docker_version is requested.
+# Docker version mapping. Ubuntu 24.04 is "noble".
+#   "29"   — latest 29.x (apt glob 29.*)
+#   "29.0" — 29.0.x only (apt glob 29.0.*)
+# The last key is the default when no docker_version is requested.
 docker_version_map:
   "29.0":
+    package:
+      - docker-ce=5:29.0.*
+      - docker-ce-cli=5:29.0.*
+      - containerd.io
+    repo: deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu noble stable
+    keys:
+      server: https://download.docker.com/linux/ubuntu/gpg
+      dest: /etc/apt/keyrings/docker.asc
+  "29":
     package:
       - docker-ce=5:29.*
       - docker-ce-cli=5:29.*


### PR DESCRIPTION
## Summary
- A bare major (`24`, `25`, `29`) installs the latest mapped line of that major (`24.*`, `25.*`, `29.*`).
- `24.0` / `25.0` still pin that minor line (`24.0.*` / `25.0.*`). Docker 24/25 only shipped a `.0` line, so those match the major today.
- There is **no `29.0` key**. ECE needs Docker 29.3+; 29.0–29.2 are not a supported runtime. Pass `29` for latest 29.x.
- If a caller passes a bare major that is not itself a key, the role resolves to the last `{major}.*` map entry. A real minor key such as `24.0` is never rewritten.

**Breaking:** Ubuntu 24 / RHEL 9 / SLES used to treat `29.0` as a matrix label for any 29.x. That key is gone. Callers must pass `29`.

Related ECE IT matrix work: elastic/cloud#158633

## Test plan
- [ ] Ubuntu 22.04: `docker_version=25` installs latest 25.x; `25.0` still installs 25.0.x
- [ ] Ubuntu 24.04: `docker_version=29` installs latest 29.x; `29.0` is rejected
- [ ] RHEL 9 experimental Docker: same `29` key, no `29.0`
- [ ] SLES 15: `29` stays on the current 29.7.2 static pin; `25` / `25.0` stay on 25.0.5
- [ ] Unset `docker_version` still defaults to the last map key (latest major)

<small>*(AI-authored via Cursor 🤖)*</small>